### PR TITLE
Add initial version of utility scripts, fixes #7

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,6 @@ beautifulsoup4>=4.10.0
 lxml>=4.8.0
 dataretrieval>=1.0.0
 openpyxl>=3.0.0
+xarray
+tqdm
+zarr

--- a/scripts/download_all.py
+++ b/scripts/download_all.py
@@ -1,0 +1,119 @@
+"""Downloads all available streamflow data from all sites in all countries."""
+
+import os
+import importlib
+import pkgutil
+import concurrent.futures
+import logging
+import random
+import sys
+
+# Add rivretrieve to path
+sys.path.append(os.path.join(os.path.dirname(__file__), "rivretrieve"))
+
+import rivretrieve
+
+# Configuration
+ROOT_DIR = "downloaded_data"
+VARIABLE = "discharge"
+START_DATE = "1950-01-01"
+END_DATE = "2025-10-03"
+N_WORKERS = 8
+
+# Japan specific dates
+JAPAN_START_DATE = "1980-01-01"
+JAPAN_END_DATE = "2024-12-31"
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def get_fetcher_classes():
+    """Dynamically imports all RiverDataFetcher subclasses from rivretrieve."""
+    fetchers = {}
+    package = rivretrieve
+    for _, module_name, _ in pkgutil.iter_modules(package.__path__):
+        if module_name not in ["base", "utils"]:
+            module = importlib.import_module(f".{module_name}", package.__name__)
+            for attribute_name in dir(module):
+                attribute = getattr(module, attribute_name)
+                try:
+                    if issubclass(attribute, rivretrieve.base.RiverDataFetcher) and attribute is not rivretrieve.base.RiverDataFetcher:
+                        fetchers[module_name] = attribute
+                        logging.info(f"Found fetcher: {attribute_name} in {module_name}")
+                except TypeError:
+                    continue
+    return fetchers
+
+def download_site_data(country, fetcher_class, site_id, start_date, end_date):
+    """Downloads and saves data for a single site."""
+    output_dir = os.path.join(ROOT_DIR, country)
+    os.makedirs(output_dir, exist_ok=True)
+
+    # Sanitize site_id to be used as a filename
+    sanitized_site_id = "".join(c if c.isalnum() or c in ['-', '_'] else '_' for c in site_id)
+    output_file = os.path.join(output_dir, f"{sanitized_site_id}.csv")
+
+    if os.path.exists(output_file):
+        logging.info(f"Skipping {country} - {site_id} (already downloaded)")
+        return f"SKIPPED: {country} - {site_id}"
+
+    logging.info(f"Processing {country} - {site_id} with dates {start_date} to {end_date}")
+    try:
+        fetcher = fetcher_class(site_id=site_id)
+        data = fetcher.get_data(variable=VARIABLE, start_date=start_date, end_date=end_date)
+
+        if data is not None and not data.empty:
+            data.to_csv(output_file, index=False)
+            logging.info(f"Successfully downloaded and saved {country} - {site_id}")
+            return f"SUCCESS: {country} - {site_id}"
+        else:
+            logging.info(f"No data returned for {country} - {site_id}")
+            return f"NO DATA: {country} - {site_id}"
+
+    except Exception as e:
+        logging.error(f"Error downloading {country} - {site_id}: {e}", exc_info=False)
+        return f"FAILED: {country} - {site_id} - {e}"
+
+def main():
+    """Main function to download all data."""
+    logging.info("Starting data download process...")
+    fetcher_classes = get_fetcher_classes()
+
+    tasks = []
+    for country, fetcher_class in fetcher_classes.items():
+        try:
+            sites = fetcher_class.get_sites()
+            if sites is None or sites.empty:
+                logging.warning(f"No sites found for {country}")
+                continue
+
+            current_start_date = START_DATE
+            current_end_date = END_DATE
+            if country == "japan":
+                current_start_date = JAPAN_START_DATE
+                current_end_date = JAPAN_END_DATE
+
+            site_id_col = sites.columns[0]  # Assuming the first column is the site ID
+            for site_id in sites[site_id_col]:
+                tasks.append((country, fetcher_class, site_id, current_start_date, current_end_date))
+        except Exception as e:
+            logging.error(f"Error getting sites for {country}: {e}")
+
+
+    random.shuffle(tasks)
+    logging.info(f"Found {len(tasks)} total sites to process.")
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=N_WORKERS) as executor:
+        futures = [executor.submit(download_site_data, *task) for task in tasks]
+        for future in concurrent.futures.as_completed(futures):
+            try:
+                result = future.result()
+                logging.info(result)
+            except Exception as e:
+                logging.error(f"Error in worker thread: {e}")
+
+    logging.info("Data download process finished.")
+
+if __name__ == "__main__":
+    main()
+

--- a/scripts/process_data.py
+++ b/scripts/process_data.py
@@ -1,0 +1,106 @@
+"""Reads all downloaded CSV files, converts them to xarray Datasets, and concatenates them."""
+
+import os
+import glob
+import pandas as pd
+import xarray as xr
+import logging
+from tqdm import tqdm
+
+# Configuration
+ROOT_DIR = "downloaded_data"
+OUTPUT_FILE = "all_streamflow.zarr"
+COMMON_START_DATE = "1950-01-01"
+COMMON_END_DATE = "2025-10-06"
+DATE_RANGE = pd.date_range(start=COMMON_START_DATE, end=COMMON_END_DATE, freq='D')
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
+
+def process_csv_to_xarray(file_path):
+    """Reads a CSV file and converts it to a a properly formatted xarray Dataset."""
+    try:
+        # Extract country and site_id
+        parts = file_path.split(os.sep)
+        country = parts[-2]
+        sanitized_site_id = os.path.splitext(parts[-1])[0]
+
+        site_id = sanitized_site_id
+        if country == "uk":
+            # For UK, extract the UUID part after the last '_'
+            site_id = sanitized_site_id.split('_')[-1]
+
+        gauge_id = f"{country}_{site_id}"
+
+        df = pd.read_csv(file_path)
+
+        if 'Date' not in df.columns or 'Q' not in df.columns:
+            logging.warning(f"Skipping {file_path}: Missing 'Date' or 'Q' column.")
+            return None
+
+        df['Date'] = pd.to_datetime(df['Date'])
+        df = df.rename(columns={"Date": "time", "Q": "streamflow"})
+        df = df.set_index('time')
+
+        # Reindex to the common date range
+        df = df.reindex(DATE_RANGE)
+
+        if df.empty:
+            logging.info(f"Skipping {file_path}: No data after processing.")
+            return None
+
+        # Convert to xarray Dataset
+        ds = xr.Dataset.from_dataframe(df)
+        ds = ds.assign_coords(gauge_id=gauge_id)
+        ds = ds.expand_dims("gauge_id")
+
+        return ds
+
+    except Exception as e:
+        logging.error(f"Error processing {file_path}: {e}")
+        return None
+
+def main():
+    """Main function to process all CSV files."""
+    logging.info("Starting data processing...")
+
+    csv_files = glob.glob(os.path.join(ROOT_DIR, "**", "*.csv"), recursive=True)
+    logging.info(f"Found {len(csv_files)} CSV files to process.")
+
+    datasets = []
+
+    for file_path in tqdm(csv_files, desc="Processing CSVs"):
+
+        ds = process_csv_to_xarray(file_path)
+
+        if ds is not None:
+
+            datasets.append(ds)
+
+    if not datasets:
+
+        logging.warning("No datasets were successfully processed.")
+
+        return
+
+    logging.info(f"Successfully processed {len(datasets)} files.")
+
+    # Concatenate all datasets
+    try:
+        logging.info("Concatenating datasets...")
+        combined_ds = xr.concat(datasets, dim="gauge_id")
+        logging.info("Concatenation complete.")
+
+        # Save the combined dataset to Zarr
+        logging.info(f"Saving combined dataset to {OUTPUT_FILE}...")
+        combined_ds.to_zarr(OUTPUT_FILE, mode='w')
+        logging.info(f"Successfully saved to {OUTPUT_FILE}.")
+        print(combined_ds)
+
+    except Exception as e:
+        logging.error(f"Error during concatenation or saving: {e}")
+
+    logging.info("Data processing finished.")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds two scripts.

- download_all.py: A script that downloads all stations from all countries/fetchers using a ThreadPool. Downloaded data is saved to per-site csv files in a subdirectory structure of one directory per country/fetcher. Upon retry, it skips already downloaded sites.
- process_data.py: A script that loads the data from all csv files, creates a single xr.Dataset (indexed by gauge_id and time) and saves the data to zarr.

Future improvements:
- Make input and output paths in both scripts command line arguments.
- Make number of threadpool workers a command line argument.
- Dynamically get the min/max dates, instead of using hard-coded ones. If data is not re-indexed before being merged, xarray complains (and will break in the future).