### PR TITLE
Refactor: Fetcher classes can now be reused for multiple stations

### DIFF
--- a/examples/test_australia_fetcher.py
+++ b/examples/test_australia_fetcher.py
@@ -17,10 +17,12 @@ end_date = "2024-03-31"
 
 plt.figure(figsize=(12, 6))
 
+fetcher = AustraliaFetcher()
 for gauge_id in gauge_ids:
-    fetcher = AustraliaFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id} from {start_date} to {end_date}...")
-    data = fetcher.get_data(variable=variable)
+    data = fetcher.get_data(
+        gauge_id=gauge_id, variable=variable, start_date=start_date, end_date=end_date
+    )
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_brazil_fetcher.py
+++ b/examples/test_brazil_fetcher.py
@@ -14,15 +14,23 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = BrazilFetcher()
 for gauge_id in gauge_ids:
-    fetcher = BrazilFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable)
+    data = fetcher.get_data(gauge_id=gauge_id, variable=variable)
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())
-        print(f"Time series from {data[constants.TIME_INDEX].min()} to {data[constants.TIME_INDEX].max()}")
-        plt.plot(data[constants.TIME_INDEX], data[constants.DISCHARGE], label=gauge_id, marker=".", linestyle="-")
+        print(
+            f"Time series from {data[constants.TIME_INDEX].min()} to {data[constants.TIME_INDEX].max()}"
+        )
+        plt.plot(
+            data[constants.TIME_INDEX],
+            data[constants.DISCHARGE],
+            label=gauge_id,
+            marker=".",
+            linestyle="-",
+        )
     else:
         print(f"No data found for {gauge_id}")
 

--- a/examples/test_canada_fetcher.py
+++ b/examples/test_canada_fetcher.py
@@ -14,10 +14,10 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = CanadaFetcher()
 for gauge_id in gauge_ids:
-    fetcher = CanadaFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable)
+    data = fetcher.get_data(gauge_id=gauge_id, variable=variable)
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_chile_fetcher.py
+++ b/examples/test_chile_fetcher.py
@@ -14,10 +14,10 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = ChileFetcher()
 for gauge_id in gauge_ids:
-    fetcher = ChileFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable)
+    data = fetcher.get_data(gauge_id=gauge_id, variable=variable)
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_france_fetcher.py
+++ b/examples/test_france_fetcher.py
@@ -14,10 +14,10 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = FranceFetcher()
 for gauge_id in gauge_ids:
-    fetcher = FranceFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable)
+    data = fetcher.get_data(gauge_id=gauge_id, variable=variable)
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_japan_fetcher.py
+++ b/examples/test_japan_fetcher.py
@@ -16,10 +16,12 @@ end_date = "2019-12-31"  # Fetching a few months to test
 
 plt.figure(figsize=(12, 6))
 
+fetcher = JapanFetcher()
 for gauge_id in gauge_ids:
-    fetcher = JapanFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id} from {start_date} to {end_date}...")
-    data = fetcher.get_data(variable=variable, start_date=start_date, end_date=end_date)
+    data = fetcher.get_data(
+        gauge_id=gauge_id, variable=variable, start_date=start_date, end_date=end_date
+    )
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_poland_fetcher.py
+++ b/examples/test_poland_fetcher.py
@@ -18,10 +18,15 @@ end_date = "2001-12-31"
 for variable in variables:
     plt.figure(figsize=(12, 6))
     print(f"\nTesting variable: {variable}")
+    fetcher = PolandFetcher()
     for gauge_id in gauge_ids:
-        fetcher = PolandFetcher(gauge_id=gauge_id)
         print(f"Fetching {variable} for {gauge_id} from {start_date} to {end_date}...")
-        data = fetcher.get_data(variable=variable, start_date=start_date, end_date=end_date)
+        data = fetcher.get_data(
+            gauge_id=gauge_id,
+            variable=variable,
+            start_date=start_date,
+            end_date=end_date,
+        )
         if not data.empty:
             print(f"Data for {gauge_id}:")
             print(data.head())
@@ -41,7 +46,9 @@ for variable in variables:
     if "data" in locals() and not data.empty:
         plt.xlabel(constants.TIME_INDEX)
         plt.ylabel(f"{variable}")
-        plt.title(f"Poland River {variable} ({gauge_ids[0]} - {start_date} to {end_date})")
+        plt.title(
+            f"Poland River {variable} ({gauge_ids[0]} - {start_date} to {end_date})"
+        )
         plt.legend()
         plt.grid(True)
         plt.tight_layout()

--- a/examples/test_slovenia_fetcher.py
+++ b/examples/test_slovenia_fetcher.py
@@ -14,10 +14,12 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = SloveniaFetcher()
 for gauge_id in gauge_ids:
-    fetcher = SloveniaFetcher(gauge_id=gauge_id)
     print(f"Fetching all data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable)  # Removed start_date and end_date
+    data = fetcher.get_data(
+        gauge_id=gauge_id, variable=variable
+    )  # Removed start_date and end_date
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_southafrica_fetcher.py
+++ b/examples/test_southafrica_fetcher.py
@@ -14,10 +14,10 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = SouthAfricaFetcher()
 for gauge_id in gauge_ids:
-    fetcher = SouthAfricaFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable)
+    data = fetcher.get_data(gauge_id=gauge_id, variable=variable)
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_uk_fetcher.py
+++ b/examples/test_uk_fetcher.py
@@ -12,10 +12,12 @@ variable = constants.DISCHARGE
 
 plt.figure(figsize=(12, 6))
 
+fetcher = UKFetcher()
 for gauge_id in gauge_ids:
-    fetcher = UKFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id}...")
-    data = fetcher.get_data(variable=variable, start_date=start_date, end_date=end_date)
+    data = fetcher.get_data(
+        gauge_id=gauge_id, variable=variable, start_date=start_date, end_date=end_date
+    )
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/examples/test_usa_fetcher.py
+++ b/examples/test_usa_fetcher.py
@@ -17,10 +17,12 @@ end_date = None
 
 plt.figure(figsize=(12, 6))
 
+fetcher = USAFetcher()
 for gauge_id in gauge_ids:
-    fetcher = USAFetcher(gauge_id=gauge_id)
     print(f"Fetching data for {gauge_id} from {start_date} to {end_date}...")
-    data = fetcher.get_data(variable=variable, start_date=start_date, end_date=end_date)
+    data = fetcher.get_data(
+        gauge_id=gauge_id, variable=variable, start_date=start_date, end_date=end_date
+    )
     if not data.empty:
         print(f"Data for {gauge_id}:")
         print(data.head())

--- a/rivretrieve/base.py
+++ b/rivretrieve/base.py
@@ -9,17 +9,14 @@ import pandas as pd
 class RiverDataFetcher(abc.ABC):
     """Abstract base class for fetching river gauge data."""
 
-    def __init__(self, gauge_id: str):
-        """Initializes the data fetcher.
-
-        Args:
-            gauge_id: The site-specific identifier for the gauge.
-        """
-        self.gauge_id = gauge_id
+    def __init__(self):
+        """Initializes the data fetcher."""
+        pass
 
     @abc.abstractmethod
     def get_data(
         self,
+        gauge_id: str,
         variable: str,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
@@ -27,6 +24,7 @@ class RiverDataFetcher(abc.ABC):
         """Fetches the time series data for the given variable and date range.
 
         Args:
+            gauge_id: The site-specific identifier for the gauge.
             variable: The variable to fetch (e.g., 'stage' or 'discharge').
             start_date: Optional start date in 'YYYY-MM-DD' format.
             end_date: Optional end date in 'YYYY-MM-DD' format.
@@ -53,10 +51,13 @@ class RiverDataFetcher(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _download_data(self, variable: str, start_date: str, end_date: str) -> any:
+    def _download_data(
+        self, gauge_id: str, variable: str, start_date: str, end_date: str
+    ) -> any:
         """Downloads the raw data from the source.
 
         Args:
+            gauge_id: The site-specific identifier for the gauge.
             variable: The variable to fetch.
             start_date: Start date in 'YYYY-MM-DD' format.
             end_date: End date in 'YYYY-MM-DD' format.
@@ -67,10 +68,11 @@ class RiverDataFetcher(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def _parse_data(self, raw_data: any, variable: str) -> pd.DataFrame:
+    def _parse_data(self, gauge_id: str, raw_data: any, variable: str) -> pd.DataFrame:
         """Parses the raw data into a standardized pandas DataFrame.
 
         Args:
+            gauge_id: The site-specific identifier for the gauge.
             raw_data: The raw data from _download_data.
             variable: The variable being parsed.
 

--- a/rivretrieve/canada.py
+++ b/rivretrieve/canada.py
@@ -121,6 +121,7 @@ class CanadaFetcher(base.RiverDataFetcher):
 
     def get_data(
         self,
+        gauge_id: str,
         variable: str,
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
@@ -153,7 +154,7 @@ class CanadaFetcher(base.RiverDataFetcher):
                   AND YEAR BETWEEN ? AND ?
             """
             df = pd.read_sql_query(
-                query, conn, params=(self.gauge_id, start_dt.year, end_dt.year)
+                query, conn, params=(gauge_id, start_dt.year, end_dt.year)
             )
             conn.close()
 
@@ -203,13 +204,15 @@ class CanadaFetcher(base.RiverDataFetcher):
 
         except Exception as e:
             logger.error(
-                f"Error querying or processing HYDAT for site {self.gauge_id}, variable {variable}: {e}"
+                f"Error querying or processing HYDAT for site {gauge_id}, variable {variable}: {e}"
             )
             return pd.DataFrame(columns=[constants.TIME_INDEX, variable])
 
     # These are not used for Canada as data is local
-    def _download_data(self, variable: str, start_date: str, end_date: str) -> Any:
+    def _download_data(
+        self, gauge_id: str, variable: str, start_date: str, end_date: str
+    ) -> Any:
         return None
 
-    def _parse_data(self, raw_data: Any, variable: str) -> pd.DataFrame:
+    def _parse_data(self, gauge_id: str, raw_data: Any, variable: str) -> pd.DataFrame:
         return pd.DataFrame()

--- a/scripts/download_all.py
+++ b/scripts/download_all.py
@@ -74,9 +74,12 @@ def download_gauge_data(country, fetcher_class, gauge_id, start_date, end_date):
         f"Processing {country} - {gauge_id} with dates {start_date} to {end_date}"
     )
     try:
-        fetcher = fetcher_class(gauge_id=gauge_id)
+        fetcher = fetcher_class()
         data = fetcher.get_data(
-            variable=VARIABLE, start_date=start_date, end_date=end_date
+            gauge_id=gauge_id,
+            variable=VARIABLE,
+            start_date=start_date,
+            end_date=end_date,
         )
 
         if data is not None and not data.empty:


### PR DESCRIPTION
Changed the class structure so that fetcher objects are not initialized per gauge id anymore. Instead, the fetcher instances accept the gauge_id as input to get_data and can now be re-used to get data for all stations from within one country, without re-initializing the object.