### PR TITLE
Add Netherlands

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -17,6 +17,7 @@ API Reference
    fetchers/germany_berlin
    fetchers/japan
    fetchers/lithuania
+   fetchers/netherlands
    fetchers/norway
    fetchers/poland
    fetchers/portugal

--- a/docs/fetchers/netherlands.rst
+++ b/docs/fetchers/netherlands.rst
@@ -1,0 +1,24 @@
+Netherlands Fetcher
+===================
+
+The Netherlands fetcher wraps Rijkswaterstaat WaterWebservices metadata and
+observation endpoints for surface-water gauges.
+
+Implemented support includes:
+
+- discharge daily mean and instantaneous
+- stage daily mean and instantaneous
+- water temperature daily mean and instantaneous
+
+Implementation notes:
+
+- live metadata is sourced from the Rijkswaterstaat catalog
+- cached metadata is stored in ``rivretrieve/cached_site_data/netherlands_sites.csv``
+- the fetcher prefers the current ``ddapi20`` endpoint family and falls back to the
+  legacy WaterWebservices endpoints when needed
+- daily series are aggregated from sub-daily observations
+- stage values are converted from centimeters to meters
+- provider sentinel values are filtered from temperature series before aggregation
+
+.. automodule:: rivretrieve.netherlands
+   :members:

--- a/docs/fetchers/netherlands.rst
+++ b/docs/fetchers/netherlands.rst
@@ -1,24 +1,5 @@
 Netherlands Fetcher
 ===================
 
-The Netherlands fetcher wraps Rijkswaterstaat WaterWebservices metadata and
-observation endpoints for surface-water gauges.
-
-Implemented support includes:
-
-- discharge daily mean and instantaneous
-- stage daily mean and instantaneous
-- water temperature daily mean and instantaneous
-
-Implementation notes:
-
-- live metadata is sourced from the Rijkswaterstaat catalog
-- cached metadata is stored in ``rivretrieve/cached_site_data/netherlands_sites.csv``
-- the fetcher prefers the current ``ddapi20`` endpoint family and falls back to the
-  legacy WaterWebservices endpoints when needed
-- daily series are aggregated from sub-daily observations
-- stage values are converted from centimeters to meters
-- provider sentinel values are filtered from temperature series before aggregation
-
 .. automodule:: rivretrieve.netherlands
    :members:

--- a/examples/test_netherlands_fetcher.py
+++ b/examples/test_netherlands_fetcher.py
@@ -1,0 +1,35 @@
+import logging
+
+import matplotlib.pyplot as plt
+
+from rivretrieve import NetherlandsFetcher, constants
+
+logging.basicConfig(level=logging.INFO)
+
+fetcher = NetherlandsFetcher()
+
+examples = [
+    ("almen", constants.DISCHARGE_DAILY_MEAN, "2025-01-01", "2025-01-07"),
+    ("a12", constants.STAGE_INSTANT, "2025-01-01", "2025-01-01"),
+    ("ameland.nes", constants.WATER_TEMPERATURE_DAILY_MEAN, "2025-07-01", "2025-07-03"),
+]
+
+for gauge_id, variable, start_date, end_date in examples:
+    data = fetcher.get_data(gauge_id=gauge_id, variable=variable, start_date=start_date, end_date=end_date)
+
+    if data.empty:
+        print(f"No data found for {gauge_id} ({variable})")
+        continue
+
+    print(data.head())
+    plt.figure(figsize=(12, 6))
+    plt.plot(data.index, data[variable], label=f"{gauge_id} - {variable}")
+    plt.xlabel(constants.TIME_INDEX)
+    plt.ylabel(variable)
+    plt.title(f"Netherlands River Data ({gauge_id})")
+    plt.legend()
+    plt.grid(True)
+    plt.tight_layout()
+    plot_path = f"netherlands_{gauge_id}_{variable}.png".replace(".", "_")
+    plt.savefig(plot_path)
+    print(f"Plot saved to {plot_path}")

--- a/rivretrieve/__init__.py
+++ b/rivretrieve/__init__.py
@@ -10,6 +10,7 @@ from .france import FranceFetcher
 from .germany_berlin import GermanyBerlinFetcher
 from .japan import JapanFetcher
 from .lithuania import LithuaniaFetcher
+from .netherlands import NetherlandsFetcher
 from .norway import NorwayFetcher
 from .poland import PolandFetcher
 from .portugal import PortugalFetcher

--- a/rivretrieve/cached_site_data/netherlands_sites.csv
+++ b/rivretrieve/cached_site_data/netherlands_sites.csv
@@ -1,0 +1,1828 @@
+gauge_id,station_name,river,latitude,longitude,altitude,area,country,source
+4epetroleumhaven,4e Petroleumhaven,4e Petroleumhaven,51.953524,4.140491,,,Netherlands,Rijkswaterstaat WaterWebservices
+7epetroleumhaven,7e Petroleumhaven,7e Petroleumhaven,51.915615,4.21277,,,Netherlands,Rijkswaterstaat WaterWebservices
+a12,A12 platform,A12 platform,55.383333,3.8,,,Netherlands,Rijkswaterstaat WaterWebservices
+aa.helmond,"Aa, Helmond","Aa, Helmond",51.488763,5.682549,,,Netherlands,Rijkswaterstaat WaterWebservices
+aadorp,Aadorp,Aadorp,52.3726,6.6333,,,Netherlands,Rijkswaterstaat WaterWebservices
+aakvlaai.badstrand,"Aakvlaai, badstrand","Aakvlaai, badstrand",51.723572,4.864773,,,Netherlands,Rijkswaterstaat WaterWebservices
+aalst.deneswaarden,"Aalst, De Neswaarden","Aalst, De Neswaarden",51.785668,5.115173,,,Netherlands,Rijkswaterstaat WaterWebservices
+aalst.derietschoof.1,"Aalst, De Rietschoof, meetpunt 1",strand,51.77674,5.125978,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.goorloop.wilhelminakanaal,"Aarle-Rixtel, Goorloop, Wilhelminakanaal","Aarle-Rixtel, Goorloop, Wilhelminakanaal",51.513289,5.612911,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert,"Aarle Rixtel, Schabbert","Aarle Rixtel, Schabbert",51.520597,5.654069,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert.beneden,"Aarle Rixtel, Schabbert, beneden","Aarle Rixtel, Schabbert, beneden",51.5212,5.6534,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert.boven,"Aarle Rixtel, Schabbert, boven","Aarle Rixtel, Schabbert, boven",51.5205,5.6542,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert.inlaat,"Aarle Rixtel, Schabbert, inlaat",Spuien,51.521269,5.653569,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert.kleplinks,"Aarle Rixtel, Schabbert, klep links","Aarle Rixtel, Schabbert, klep links",51.521261,5.653569,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert.kleprechts,"Aarle Rixtel, Schabbert, klep rechts","Aarle Rixtel, Schabbert, klep rechts",51.521267,5.653569,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.schabbert.uitlaat,"Aarle Rixtel, Schabbert, uitlaat",NettobalansUIT,51.521264,5.653569,,,Netherlands,Rijkswaterstaat WaterWebservices
+aarlerixtel.whkgoorloop,"Aarle-Rixtel, WHK-Goorloop",AA21,51.513286,5.612912,,,Netherlands,Rijkswaterstaat WaterWebservices
+aasterberg,Aasterberg,monding van de Geleenbeek,51.10176,5.834066,,,Netherlands,Rijkswaterstaat WaterWebservices
+abbertstrand,Abbertstrand,Abbertstrand,52.51092,5.853608,,,Netherlands,Rijkswaterstaat WaterWebservices
+adelaarsweg,Adelaarsweg,Hoge Vaart,52.328631,5.423878,,,Netherlands,Rijkswaterstaat WaterWebservices
+alblasserdam,Alblasserdam,rechteroever nabij brug,51.856606,4.656146,,,Netherlands,Rijkswaterstaat WaterWebservices
+alblasserdam.pijlstoep,"Alblasserdam, Pijlstoep","Alblasserdam, Pijlstoep",51.865838,4.645151,,,Netherlands,Rijkswaterstaat WaterWebservices
+almeerderstrand,Almeerderstrand,Almeerderstrand,52.33544,5.138603,,,Netherlands,Rijkswaterstaat WaterWebservices
+almelo,Almelo,Almelo,52.35632,6.620117,,,Netherlands,Rijkswaterstaat WaterWebservices
+almen,Almen,Almen,52.165824,6.28472,,,Netherlands,Rijkswaterstaat WaterWebservices
+almere.hollandsebrug,"Almere, Hollandse brug","Almere, Hollandse brug",52.3265,5.1376,,,Netherlands,Rijkswaterstaat WaterWebservices
+almere.lagevaart,"Almere, Lage Vaart","Almere, Lage Vaart",52.398658,5.247623,,,Netherlands,Rijkswaterstaat WaterWebservices
+almere.triathlon.a,"Almere, triathlon, punt A","Almere, triathlon, punt A",52.333802,5.200878,,,Netherlands,Rijkswaterstaat WaterWebservices
+almere.triathlon.b,"Almere, triathlon, punt B","Almere, triathlon, punt B",52.329379,5.212075,,,Netherlands,Rijkswaterstaat WaterWebservices
+almere.triathlon.c,"Almere, triathlon, punt C","Almere, triathlon, punt C",52.332949,5.219778,,,Netherlands,Rijkswaterstaat WaterWebservices
+almerehaven.zwemstrand,"Almere-Haven, zwemstrand","Almere-Haven, zwemstrand",52.332849,5.212678,,,Netherlands,Rijkswaterstaat WaterWebservices
+ameland.nes,"Ameland, Nes","Ameland, Nes",53.429766,5.759448,,,Netherlands,Rijkswaterstaat WaterWebservices
+ameland.nes.badstrand,"Ameland, Nes, badstrand","Ameland, Nes, badstrand",53.462079,5.778186,,,Netherlands,Rijkswaterstaat WaterWebservices
+ameland.noord,"Ameland, noord","Ameland, noord",53.46723,5.788562,,,Netherlands,Rijkswaterstaat WaterWebservices
+ameland.oost,"Ameland, oost","Ameland, oost",53.455501,5.971668,,,Netherlands,Rijkswaterstaat WaterWebservices
+ameland.westgat,"Ameland, Westgat",platform,53.491639,5.941194,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelandergat,Amelander Gat,Amelander Gat,53.467071,5.567896,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.1.1,"Amelander zeegat, 1 .1",boei,53.507601,5.481405,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.1.2,"Amelander zeegat, 1 .2",boei,53.507598,5.48442,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.2.1,"Amelander zeegat, 2 .1",boei,53.477304,5.573963,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.3.1,"Amelander zeegat, 3 .1",boei,53.450839,5.60365,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.3.2,"Amelander zeegat, 3 .2",boei,53.449939,5.604699,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.4.1,"Amelander zeegat, 4 .1",boei,53.421114,5.641855,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.4.2,"Amelander zeegat, 4 .2",boei,53.424273,5.635406,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelanderzeegat.5.2,"Amelander zeegat, 5 .2",boei,53.393401,5.696857,,,Netherlands,Rijkswaterstaat WaterWebservices
+amelandwestgat,Ameland Westgat platform,Ameland Westgat platform,53.49164,5.94114,,,Netherlands,Rijkswaterstaat WaterWebservices
+amerikahaven.2,"Amerikahaven, 2","Amerikahaven, 2",52.411987,4.774766,,,Netherlands,Rijkswaterstaat WaterWebservices
+amerikahaven.zuid,"Amerikahaven, zuid","Amerikahaven, zuid",52.401564,4.77538,,,Netherlands,Rijkswaterstaat WaterWebservices
+amerongen.beneden,"Amerongen, beneden","Amerongen, beneden",51.974,5.404,,,Netherlands,Rijkswaterstaat WaterWebservices
+amerongen.boven,"Amerongen, boven","Amerongen, boven",51.9753,5.4125,,,Netherlands,Rijkswaterstaat WaterWebservices
+amerongen.eckenwiel,"Amerongen, Eck en Wiel","Amerongen, Eck en Wiel",51.983031,5.455764,,,Netherlands,Rijkswaterstaat WaterWebservices
+ammerstol.dehem.badstrand,"Ammerstol, De Hem, badstrand","Ammerstol, De Hem, badstrand",51.941746,4.832526,,,Netherlands,Rijkswaterstaat WaterWebservices
+amsteldiep,Amsteldiep,Amsteldiep,52.929371,4.911323,,,Netherlands,Rijkswaterstaat WaterWebservices
+amsterdam.km25,"Amsterdam, km 25",IJtunnel,52.380775,4.905707,,,Netherlands,Rijkswaterstaat WaterWebservices
+amsterdam.ndsmwerf,"Amsterdam, NDSM werf","Amsterdam, NDSM werf",52.399863,4.888014,,,Netherlands,Rijkswaterstaat WaterWebservices
+amsterdam.schellingwouderbrug,"Amsterdam, Schellingwouderbrug","Amsterdam, Schellingwouderbrug",52.378673,4.967545,,,Netherlands,Rijkswaterstaat WaterWebservices
+amsterdam.surinamekade,"Amsterdam, Surinamekade","Amsterdam, Surinamekade",52.37726,4.949568,,,Netherlands,Rijkswaterstaat WaterWebservices
+andel.maas,"Andel, Maas","Andel, Maas",51.794083,5.050327,,,Netherlands,Rijkswaterstaat WaterWebservices
+andel.waal,"Andel, Waal","Andel, Waal",51.794799,5.049162,,,Netherlands,Rijkswaterstaat WaterWebservices
+andijk,Andijk,"voorheen IJsselmeer, meetpaal 38",52.7503,5.265049,,,Netherlands,Rijkswaterstaat WaterWebservices
+ane.h56,"Ane, H56","Ane, H56",52.611501,6.658118,,,Netherlands,Rijkswaterstaat WaterWebservices
+antwerpen.bonapartedok,"Antwerpen, Bonapartedok","Antwerpen, Bonapartedok",51.22835,4.399894,,,Netherlands,Rijkswaterstaat WaterWebservices
+antwerpen.loodsgebouw,"Antwerpen, Loodsgebouw","Antwerpen, Loodsgebouw",51.227537,4.399894,,,Netherlands,Rijkswaterstaat WaterWebservices
+antwerpen.prosperpolder,"Antwerpen, Prosperpolder","Antwerpen, Prosperpolder",51.342082,4.247633,,,Netherlands,Rijkswaterstaat WaterWebservices
+antwerpskanaalpand.km2,"Antwerps Kanaalpand, kilometer 02","Antwerps Kanaalpand, kilometer 02",51.38782,4.245773,,,Netherlands,Rijkswaterstaat WaterWebservices
+appelzak.1kmuitdekust,"Appelzak, 1 km uit de kust","Appelzak, 1 km uit de kust",51.380221,3.365682,,,Netherlands,Rijkswaterstaat WaterWebservices
+appelzak.2kmuitdekust,"Appelzak, 2 km uit de kust","Appelzak, 2 km uit de kust",51.385216,3.350962,,,Netherlands,Rijkswaterstaat WaterWebservices
+appelzak.4kmuitdekust,"Appelzak, 4 km uit de kust","Appelzak, 4 km uit de kust",51.397999,3.329852,,,Netherlands,Rijkswaterstaat WaterWebservices
+arcen,Arcen,Arcen,51.473238,6.178836,,,Netherlands,Rijkswaterstaat WaterWebservices
+archem.benedenregge,"Archem, Beneden Regge","Archem, Beneden Regge",52.468781,6.451574,,,Netherlands,Rijkswaterstaat WaterWebservices
+archem.linderbeek,"Archem, Linderbeek",km 0.1,52.469438,6.45343,,,Netherlands,Rijkswaterstaat WaterWebservices
+arnemuiden.oranjeplaat,Arnemuiden Oranjeplaat,Arnemuiden Oranjeplaat,51.51661,3.70014,,,Netherlands,Rijkswaterstaat WaterWebservices
+arnhem.nederrijn,"Arnhem, Nederrijn","Arnhem, Nederrijn",51.975408,5.912023,,,Netherlands,Rijkswaterstaat WaterWebservices
+baarland.badstrand,"Baarland, badstrand","Baarland, badstrand",51.394415,3.898086,,,Netherlands,Rijkswaterstaat WaterWebservices
+badstrandburen.ameland,"Badstrand Buren, Ameland","Badstrand Buren, Ameland",53.463349,5.809289,,,Netherlands,Rijkswaterstaat WaterWebservices
+badstrandhoorn.terschelling,"Badstrand Hoorn, Terschelling","Badstrand Hoorn, Terschelling",53.416362,5.342075,,,Netherlands,Rijkswaterstaat WaterWebservices
+badstrandprinsbernhardweg.schiermonnikoog,"Badstrand Prins Bernhardweg, Schiermonnikoog","Badstrand Prins Bernhardweg, Schiermonnikoog",53.503886,6.190084,,,Netherlands,Rijkswaterstaat WaterWebservices
+bath.badstrand,"Bath, badstrand","Bath, badstrand",51.400328,4.210825,,,Netherlands,Rijkswaterstaat WaterWebservices
+bath.boei68,"Bath, boei 68","Bath, boei 68",51.390355,4.206915,,,Netherlands,Rijkswaterstaat WaterWebservices
+bath.boei71,"Bath, boei 71","Bath, boei 71",51.38368,4.165426,,,Netherlands,Rijkswaterstaat WaterWebservices
+bathsespuikanaal.zuid,"Bathse Spuikanaal, zuid","Bathse Spuikanaal, zuid",51.402104,4.235643,,,Netherlands,Rijkswaterstaat WaterWebservices
+bazeldijk,Bazeldijk,kilometer 14.5,51.900515,4.995334,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.biezenloop,"Beek en Donk, Biezenloop",AA06,51.559923,5.606078,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.beneden,"Beek en donk, sluis 6, beneden","Beek en donk, sluis 6, beneden",51.538,5.633,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.boven,"Beek en donk, sluis 6, boven","Beek en donk, sluis 6, boven",51.5369,5.6343,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.inlaat,"Beek en Donk, Sluis 6, inlaat",Spuien,51.539903,5.630658,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.kolk,Beek En Donk Sluis6 kolk,Beek En Donk Sluis6 kolk,51.53989386,5.63065851,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.schuiflinks,Beek En Donk Sluis6 schuiflinks,Beek En Donk Sluis6 schuiflinks,51.53989386,5.63065851,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.schuifrechts,Beek En Donk Sluis6 schuifrechts,Beek En Donk Sluis6 schuifrechts,51.53989386,5.63065851,,,Netherlands,Rijkswaterstaat WaterWebservices
+beekendonk.sluis6.uitlaat,"Beek en Donk, Sluis 6, uitlaat",NettobalansUIT,51.539894,5.630658,,,Netherlands,Rijkswaterstaat WaterWebservices
+beerenplaat.loswal,"Beerenplaat, loswal","Beerenplaat, loswal",51.832075,4.397555,,,Netherlands,Rijkswaterstaat WaterWebservices
+beerkanaal,Beerkanaal,Beerkanaal,51.971117,4.097315,,,Netherlands,Rijkswaterstaat WaterWebservices
+beerkanaal.midden,"Beerkanaal, midden","Beerkanaal, midden",51.975455,4.090393,,,Netherlands,Rijkswaterstaat WaterWebservices
+belfeld.boven,"Belfeld, boven","Belfeld, boven",51.3189,6.1123,,,Netherlands,Rijkswaterstaat WaterWebservices
+bemmelsewaard,Bemmelse waard,Bemmelse waard,51.881669,5.8996,,,Netherlands,Rijkswaterstaat WaterWebservices
+benedenleeuwen,Beneden Leeuwen,Beneden Leeuwen,51.887902,5.499341,,,Netherlands,Rijkswaterstaat WaterWebservices
+beneluxhaven,Beneluxhaven,Beneluxhaven,51.943169,4.127935,,,Netherlands,Rijkswaterstaat WaterWebservices
+bergenaanzee,Bergen aan Zee,Bergen aan Zee,52.660979,4.626005,,,Netherlands,Rijkswaterstaat WaterWebservices
+bergenopzoom,Bergen op Zoom,Bergen op Zoom,51.473894,4.243875,,,Netherlands,Rijkswaterstaat WaterWebservices
+bergenopzoom.noord,"Bergen op Zoom, noord","Bergen op Zoom, noord",51.506522,4.249998,,,Netherlands,Rijkswaterstaat WaterWebservices
+bergsediepsluis.noord,"Bergse Diepsluis, noord",badstrand,51.5124,4.173062,,,Netherlands,Rijkswaterstaat WaterWebservices
+bergstoep.lek,"Bergstoep, Lek","Bergstoep, Lek",51.9157822,4.7754326,,,Netherlands,Rijkswaterstaat WaterWebservices
+berlicum.schijndelseloop,Berlicum Schijndelseloop,Berlicum Schijndelseloop,51.65749,5.40411,,,Netherlands,Rijkswaterstaat WaterWebservices
+berlicum.schijndelseloop.twoud,"Berlicum, Schijndelseloop, het Woud",AA03,51.657492,5.40411,,,Netherlands,Rijkswaterstaat WaterWebservices
+beugen,Beugen,Beugen,51.666955,5.962359,,,Netherlands,Rijkswaterstaat WaterWebservices
+beukers.boven,"Beukers, boven","Beukers, boven",52.663514,6.101702,,,Netherlands,Rijkswaterstaat WaterWebservices
+biddinghuizen.ellerstrand,"Biddinghuizen, Ellerstrand","Biddinghuizen, Ellerstrand",52.423421,5.769785,,,Netherlands,Rijkswaterstaat WaterWebservices
+biddinghuizen.flevostrand,"Biddinghuizen, Flevostrand","Biddinghuizen, Flevostrand",52.387439,5.637301,,,Netherlands,Rijkswaterstaat WaterWebservices
+biddinghuizen.harderstrand,"Biddinghuizen, Harderstrand","Biddinghuizen, Harderstrand",52.38859,5.636926,,,Netherlands,Rijkswaterstaat WaterWebservices
+biddingweg,Biddingweg,Lage Vaart,52.51577,5.633226,,,Netherlands,Rijkswaterstaat WaterWebservices
+bijland.jachthaven,"Bijland, jachthaven","recreatieplas, kilometer 863.600",51.861827,6.0942,,,Netherlands,Rijkswaterstaat WaterWebservices
+bijsselsebeek.monding,"Bijsselsebeek, monding","Bijsselsebeek, monding",52.393624,5.729759,,,Netherlands,Rijkswaterstaat WaterWebservices
+binnenschaar,Binnen Schaar,Binnen Schaar,51.648777,3.732153,,,Netherlands,Rijkswaterstaat WaterWebservices
+binnenschelde,Binnenschelde,Binnenschelde,51.493506,4.251907,,,Netherlands,Rijkswaterstaat WaterWebservices
+binnenspuikanaal.1,"Binnenspuikanaal, 1","Binnenspuikanaal, 1",52.469946,4.608883,,,Netherlands,Rijkswaterstaat WaterWebservices
+bisonbaai.midden,"Bisonbaai, midden",recreatieplas,51.867381,5.928766,,,Netherlands,Rijkswaterstaat WaterWebservices
+blaarthem,Blaarthem,Afwateringskanaal Eindhoven,51.422066,5.445859,,,Netherlands,Rijkswaterstaat WaterWebservices
+blaarthem.dommel,"Blaarthem, Dommel","Blaarthem, Dommel",51.421797,5.445428,,,Netherlands,Rijkswaterstaat WaterWebservices
+blaarthem.gender,"Blaarthem, Gender","Blaarthem, Gender",51.422875,5.445961,,,Netherlands,Rijkswaterstaat WaterWebservices
+blaricum.strandvoorland,"Blaricum, strand Voorland","Blaricum, strand Voorland",52.297694,5.29721,,,Netherlands,Rijkswaterstaat WaterWebservices
+blauweslenk.oost,"Blauwe Slenk, oost","Blauwe Slenk, oost",53.224558,5.277907,,,Netherlands,Rijkswaterstaat WaterWebservices
+blauweslenk.west,"Blauwe Slenk, west","Blauwe Slenk, west",53.230575,5.201819,,,Netherlands,Rijkswaterstaat WaterWebservices
+bleekersvallei,Bleekersvallei,Bleekersvallei,53.069571,4.725084,,,Netherlands,Rijkswaterstaat WaterWebservices
+bloemendaalaanzee,Bloemendaal aan Zee,Bloemendaal aan Zee,52.402473,4.543016,,,Netherlands,Rijkswaterstaat WaterWebservices
+bochtvanstjacob,Bocht van St Jacob,Bocht van St Jacob,51.684824,4.122738,,,Netherlands,Rijkswaterstaat WaterWebservices
+bochtvanwatum,Bocht van Watum,Bocht van Watum,53.334933,6.94394,,,Netherlands,Rijkswaterstaat WaterWebservices
+bochtvanwatum.midden.oost,"Bocht van Watum, midden, oost","Bocht van Watum, midden, oost",53.349279,6.911343,,,Netherlands,Rijkswaterstaat WaterWebservices
+bochtvanwatum.midden.west,"Bocht van Watum, midden, west","Bocht van Watum, midden, west",53.373636,6.904016,,,Netherlands,Rijkswaterstaat WaterWebservices
+bochtvanwatum.noord,"Bocht van Watum, noord","Bocht van Watum, noord",53.404581,6.894281,,,Netherlands,Rijkswaterstaat WaterWebservices
+bochtvanwatum.zuid,"Bocht van Watum, zuid","Bocht van Watum, zuid",53.33036,6.958336,,,Netherlands,Rijkswaterstaat WaterWebservices
+boerenplaat.badstrand,"Boerenplaat, badstrand","Boerenplaat, badstrand",51.731722,4.719154,,,Netherlands,Rijkswaterstaat WaterWebservices
+bommenede,Bommenede,Grevelingen boei G22,51.738709,3.974298,,,Netherlands,Rijkswaterstaat WaterWebservices
+bommenede.boeigb2,"Bommenede, boei GB2","Bommenede, boei GB2",51.733914,3.976195,,,Netherlands,Rijkswaterstaat WaterWebservices
+boomkensdiep,Boomkensdiep,Boomkensdiep,53.378964,5.167224,,,Netherlands,Rijkswaterstaat WaterWebservices
+boontjes,Boontjes,Boontjes,53.084869,5.33721,,,Netherlands,Rijkswaterstaat WaterWebservices
+borgharen.beneden,"Borgharen, beneden","Borgharen, beneden",50.869845,5.6973,,,Netherlands,Rijkswaterstaat WaterWebservices
+borgharen.boven,"Borgharen, boven","Borgharen, boven",50.868048,5.696862,,,Netherlands,Rijkswaterstaat WaterWebservices
+borgsweer.verbindingskanaal,Borgsweer stuw,Borgsweer stuw,53.297252,6.99886,,,Netherlands,Rijkswaterstaat WaterWebservices
+born,Born,Born,51.037169,5.799222,,,Netherlands,Rijkswaterstaat WaterWebservices
+borndiep,Borndiep,Borndiep,53.439163,5.601635,,,Netherlands,Rijkswaterstaat WaterWebservices
+bornrif,Bornrif,Bornrif,53.499272,5.52203,,,Netherlands,Rijkswaterstaat WaterWebservices
+borssele,Borssele,Borssele,51.410924,3.735446,,,Netherlands,Rijkswaterstaat WaterWebservices
+borssele.alpha,"Borssele, Alpha",platform,51.699917,3.056694,,,Netherlands,Rijkswaterstaat WaterWebservices
+borssele.badstrand,"Borssele, badstrand","Borssele, badstrand",51.427267,3.715151,,,Netherlands,Rijkswaterstaat WaterWebservices
+borssele.noordnol,"Borssele, Noordnol","Borssele, Noordnol",51.425532,3.707018,,,Netherlands,Rijkswaterstaat WaterWebservices
+borsselealpha,Borssele Windpark Alpha platform,Borssele Windpark Alpha platform,51.699921,3.056707,,,Netherlands,Rijkswaterstaat WaterWebservices
+boschgat,Boschgat,Boschgat,53.420822,5.551757,,,Netherlands,Rijkswaterstaat WaterWebservices
+boschgat.west,"Boschgat, west","Boschgat, west",53.403357,5.503729,,,Netherlands,Rijkswaterstaat WaterWebservices
+boschnaad.oost,"Boschnaad, oost","Boschnaad, oost",53.497972,6.523227,,,Netherlands,Rijkswaterstaat WaterWebservices
+boschwad,Boschwad,Boschwad,53.485894,6.510975,,,Netherlands,Rijkswaterstaat WaterWebservices
+bosscherveld.overlaat,"Bosscherveld, overlaat","Bosscherveld, overlaat",50.869424,5.686217,,,Netherlands,Rijkswaterstaat WaterWebservices
+botlek.geulhaven,Botlek Geulhaven,Radarpost 10,51.891814,4.312531,,,Netherlands,Rijkswaterstaat WaterWebservices
+bovenleeuwen,Boven Leeuwen,Boven Leeuwen,51.899393,5.579717,,,Netherlands,Rijkswaterstaat WaterWebservices
+bovenrijnkm857p900.rechteroever,"Bovenrijn km. 857.900, Rechter oever","Bovenrijn km. 857.900, Rechter oever",51.843996,6.163651,,,Netherlands,Rijkswaterstaat WaterWebservices
+bovensluis,Bovensluis,Bovensluis,51.692464,4.493381,,,Netherlands,Rijkswaterstaat WaterWebservices
+boxmeer,Boxmeer,Boxmeer,51.647154,5.967598,,,Netherlands,Rijkswaterstaat WaterWebservices
+braakman.havenbuitenzijdebadstrand,"Braakman, haven buitenzijde badstrand","Braakman, haven buitenzijde badstrand",51.348929,3.731802,,,Netherlands,Rijkswaterstaat WaterWebservices
+brakel,Brakel,Andelse Maas,51.826764,5.104336,,,Netherlands,Rijkswaterstaat WaterWebservices
+breda,Breda,Breda,51.59401,4.77129,,,Netherlands,Rijkswaterstaat WaterWebservices
+breehorn,Breehorn,Breehorn,52.951149,4.967626,,,Netherlands,Rijkswaterstaat WaterWebservices
+breesem.boei1,"Breesem, boei 1","Breesem, boei 1",53.116288,5.043694,,,Netherlands,Rijkswaterstaat WaterWebservices
+breezanddijk,Breezanddijk,Breezanddijk,53.009694,5.160195,,,Netherlands,Rijkswaterstaat WaterWebservices
+breezanddijk.binnen,"Breezanddijk, binnen","Breezanddijk, binnen",53.016721,5.207797,,,Netherlands,Rijkswaterstaat WaterWebservices
+breezanddijk.buiten,"Breezanddijk, buiten","Breezanddijk, buiten",53.020671,5.205247,,,Netherlands,Rijkswaterstaat WaterWebservices
+breskens,Breskens,Breskens,51.399117,3.564552,,,Netherlands,Rijkswaterstaat WaterWebservices
+breskens.badstrand,"Breskens, badstrand","Breskens, badstrand",51.40051,3.567371,,,Netherlands,Rijkswaterstaat WaterWebservices
+breskens.fortfrederikhendrik,"Breskens, Fort Frederik Hendrik","Breskens, Fort Frederik Hendrik",51.406038,3.536431,,,Netherlands,Rijkswaterstaat WaterWebservices
+breskens.handelshaven,"Breskens, Handelshaven","Breskens, Handelshaven",51.396709,3.565798,,,Netherlands,Rijkswaterstaat WaterWebservices
+breskens.nieuwesluis.badstrand,"Breskens, Nieuwesluis, badstrand","Breskens, Nieuwesluis, badstrand",51.404029,3.500878,,,Netherlands,Rijkswaterstaat WaterWebservices
+breskens.veerhaven,"Breskens, Veerhaven","Breskens, Veerhaven",51.403661,3.550427,,,Netherlands,Rijkswaterstaat WaterWebservices
+brielle,Brielle,Brielle,51.907356,4.178396,,,Netherlands,Rijkswaterstaat WaterWebservices
+brielsegat,Brielse Gat,Brielse Gat,51.927536,4.065604,,,Netherlands,Rijkswaterstaat WaterWebservices
+brienenoord,Brienenoord,kilometer 996.5,51.899898,4.525587,,,Netherlands,Rijkswaterstaat WaterWebservices
+broekerhaven.recreatiepark,"Broekerhaven, recreatiepark","Broekerhaven, recreatiepark",52.686781,5.256973,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.binnen,"Brouwersdam, binnen","Brouwersdam, binnen",51.749311,3.827074,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.brouwershavensegat.2,Brouwersdam Brouwershavense Gat 2,Brouwersdam Brouwershavense Gat 2,51.766527,3.621747,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.brouwershavensegat.8,Brouwersdam Brouwershavense Gat 8,Brouwersdam Brouwershavense Gat 8,51.74644,3.81472,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.buiten,"Brouwersdam, buiten","Brouwersdam, buiten",51.748829,3.824628,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.kabbelaarsbank,"Brouwersdam, Kabbelaarsbank","Brouwersdam, Kabbelaarsbank",51.763016,3.843696,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.spui.binnen.schuif6,Brouwersdam spuisluis binnen schuif6,Brouwersdam spuisluis binnen schuif6,51.748217,3.827374,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwersdam.spui.buiten.schuif2,Brouwersdam spuisluis buiten schuif2,Brouwersdam spuisluis buiten schuif2,51.748584,3.82584,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwershaven,Brouwershaven,Brouwershaven,51.738431,3.903034,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwershavensche.gat.08,Brouwershavensche Gat 08,Brouwershavensche Gat 08,51.75075645,3.811483912,,,Netherlands,Rijkswaterstaat WaterWebservices
+brouwershavenschegat.5,"Brouwershavensche Gat, 05","Brouwershavensche Gat, 05",51.824634,3.763258,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruggennepboven,Brug Gennep boven,Brug Gennep boven,51.681876,5.964359,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse,Bruinisse,Zijpe,51.655121,4.102756,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.binnen,"Bruinisse, binnen","Bruinisse, binnen",51.667246,4.093594,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.krammerput,Bruinisse Krammersluis krammerput,Bruinisse Krammersluis krammerput,51.666489,4.186255,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.laagbekken,Bruinisse Krammersluis laagbekken,Bruinisse Krammersluis laagbekken,51.658109,4.160037,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.oosterschelde.1,"Bruinisse Krammersluis sluis, Oosterschelde","Bruinisse Krammersluis sluis, Oosterschelde",51.661389,4.155639,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.oosterschelde.2,"Bruinisse Krammersluis, Oosterschelde",vh west,51.65922,4.14228,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.oosterscheldezijde,Krammersluis Oosterscheldezijde,Krammersluis Oosterscheldezijde,51.661389,4.155639,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.volkeraknoord,Bruinisse Krammersluis Volkerak Noord,Bruinisse Krammersluis Volkerak Noord,51.661806,4.16253,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.volkerakzijdenoord,Krammersluis volkerakzijde noord,Krammersluis volkerakzijde noord,51.661806,4.16253,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.volkerakzijdezuid,Krammersluis volkerakzijde zuid,Krammersluis volkerakzijde zuid,51.661332,4.162606,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluis.volkerakzuid,Bruinisse Krammersluis Volkerak Zuid,Bruinisse Krammersluis Volkerak Zuid,51.661332,4.162606,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.krammersluizen.krammernoord,Bruinisse Krammersluizen Krammer Noord,Bruinisse Krammersluizen Krammer Noord,51.67008,4.127,,,Netherlands,Rijkswaterstaat WaterWebservices
+bruinisse.werkhaven.badstrand,"Bruinisse, werkhaven, badstrand","Bruinisse, werkhaven, badstrand",51.668618,4.087627,,,Netherlands,Rijkswaterstaat WaterWebservices
+buggenum,Buggenum,Hanssumerweerd,51.23028,5.99525,,,Netherlands,Rijkswaterstaat WaterWebservices
+buggenum.spoorbrug,"Buggenum, spoorbrug","Buggenum, spoorbrug",51.225043,5.981423,,,Netherlands,Rijkswaterstaat WaterWebservices
+buiksloot,Buiksloot,Buiksloot,52.383478,4.907352,,,Netherlands,Rijkswaterstaat WaterWebservices
+buitenbanken.west,Buitenbanken west,Buitenbanken west,51.79502,2.97225,,,Netherlands,Rijkswaterstaat WaterWebservices
+buitenhuizen,Buitenhuizen,kilometer 10,52.433277,4.722711,,,Netherlands,Rijkswaterstaat WaterWebservices
+buizerdweg,Buizerdweg,Lage Dwarsvaart,52.486808,5.432843,,,Netherlands,Rijkswaterstaat WaterWebservices
+bunde.kanaal,"Bunde, kanaal","Bunde, kanaal",50.906308,5.7247,,,Netherlands,Rijkswaterstaat WaterWebservices
+burghsluis,Burghsluis,Burghsluis,51.6758,3.756441,,,Netherlands,Rijkswaterstaat WaterWebservices
+burghsluis.tussen.westboutenburghsluis,"Burghsluis, tussen, westbout en Burghsluis","Burghsluis, tussen, westbout en Burghsluis",51.67262,3.741229,,,Netherlands,Rijkswaterstaat WaterWebservices
+burgum.burgumerdaam.boezem,Burgum Burgumerdaam boezem,Burgum Burgumerdaam boezem,53.18486,6.00312,,,Netherlands,Rijkswaterstaat WaterWebservices
+buurse,Buurse,Buurserbeek,52.134233,6.860846,,,Netherlands,Rijkswaterstaat WaterWebservices
+cadzand.1,"Cadzand, 1",voorheen punt 02,51.390145,3.368697,,,Netherlands,Rijkswaterstaat WaterWebservices
+cadzand.2,"Cadzand, 2","Cadzand, 2",51.379298,3.376275,,,Netherlands,Rijkswaterstaat WaterWebservices
+cadzand.badstrand,"Cadzand, badstrand","Cadzand, badstrand",51.380518,3.389726,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog,Callantsoog,Callantsoog,52.837511,4.688827,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.10kmuitdekust,"Callantsoog, 10 km uit de kust","Callantsoog, 10 km uit de kust",52.896148,4.563031,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.1kmuitdekust,"Callantsoog, 01 km uit de kust","Callantsoog, 01 km uit de kust",52.862822,4.686344,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.20kmuitdekust,"Callantsoog, 20 km uit de kust","Callantsoog, 20 km uit de kust",52.912256,4.416384,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.2kmuitdekust,"Callantsoog, 2 km uit de kust","Callantsoog, 2 km uit de kust",52.864765,4.673007,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.30kmuitdekust,"Callantsoog, 30 km uit de kust","Callantsoog, 30 km uit de kust",52.925594,4.270573,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.4kmuitdekust,"Callantsoog, 4 km uit de kust","Callantsoog, 4 km uit de kust",52.868374,4.643009,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.50kmuitdekust,"Callantsoog, 50 km uit de kust","Callantsoog, 50 km uit de kust",52.958924,3.983118,,,Netherlands,Rijkswaterstaat WaterWebservices
+callantsoog.70kmuitdekust,"Callantsoog, 70 km uit de kust","Callantsoog, 70 km uit de kust",52.990585,3.680377,,,Netherlands,Rijkswaterstaat WaterWebservices
+camperduin,Camperduin,Camperduin,52.714184,4.635916,,,Netherlands,Rijkswaterstaat WaterWebservices
+campingdeschans,Camping De Schans,Camping De Schans,51.835827,5.495526,,,Netherlands,Rijkswaterstaat WaterWebservices
+capelseveer,Capelse Veer,Capelse Veer,51.719895,4.983007,,,Netherlands,Rijkswaterstaat WaterWebservices
+castricumaanzee,Castricum aan Zee,Castricum aan Zee,52.558116,4.604924,,,Netherlands,Rijkswaterstaat WaterWebservices
+colijnpad,Colijnpad,Hoge Vaart,52.555867,5.764682,,,Netherlands,Rijkswaterstaat WaterWebservices
+colijnsplaat,Colijnsplaat,Colijnsplaat,51.600882,3.85938,,,Netherlands,Rijkswaterstaat WaterWebservices
+colijnsplaat.badstrand,"Colijnsplaat, badstrand","Colijnsplaat, badstrand",51.603504,3.841332,,,Netherlands,Rijkswaterstaat WaterWebservices
+colijnweg,Colijnweg,Lage Vaart,52.575231,5.751572,,,Netherlands,Rijkswaterstaat WaterWebservices
+crobsegat,Crobse gat,recreatieplas,51.818872,5.203734,,,Netherlands,Rijkswaterstaat WaterWebservices
+culemborg,Culemborg,brug,51.961,5.214,,,Netherlands,Rijkswaterstaat WaterWebservices
+d15,D15,platform,54.325667,2.93575,,,Netherlands,Rijkswaterstaat WaterWebservices
+dalem,Dalem,voorheen Vuren,51.822,5.016527,,,Netherlands,Rijkswaterstaat WaterWebservices
+dalfsen.vechterweerd,"Dalfsen, Vechterweerd","Dalfsen, Vechterweerd",52.518103,6.211651,,,Netherlands,Rijkswaterstaat WaterWebservices
+dantziggat,Dantziggat,Dantziggat,53.401137,5.726981,,,Netherlands,Rijkswaterstaat WaterWebservices
+dantziggat.noord,"Dantziggat, noord","Dantziggat, noord",53.402502,5.720978,,,Netherlands,Rijkswaterstaat WaterWebservices
+debisonbaai,De Bisonbaai,De Bisonbaai,51.866931,5.932841,,,Netherlands,Rijkswaterstaat WaterWebservices
+deblocqvankuffeler.hogevaart,"De Blocq van Kuffeler, Hoge Vaart","De Blocq van Kuffeler, Hoge Vaart",52.415704,5.224051,,,Netherlands,Rijkswaterstaat WaterWebservices
+deblocqvankuffeler.lagevaart,"De Blocq van Kuffeler, Lage Vaart","De Blocq van Kuffeler, Lage Vaart",52.416608,5.227723,,,Netherlands,Rijkswaterstaat WaterWebservices
+deeneplaat,Deeneplaat,Deeneplaat,51.739618,4.716721,,,Netherlands,Rijkswaterstaat WaterWebservices
+degoudenham.campinghetgroeneeiland,"De Gouden Ham, Camping Het Groene Eiland","De Gouden Ham, Camping Het Groene Eiland",51.834571,5.548624,,,Netherlands,Rijkswaterstaat WaterWebservices
+degoudenham.demaaslanden,"De Gouden Ham, De Maaslanden","De Gouden Ham, De Maaslanden",51.8303,5.562303,,,Netherlands,Rijkswaterstaat WaterWebservices
+degoudenham.demaasterp,"De Gouden Ham, De Maasterp","De Gouden Ham, De Maasterp",51.834652,5.554369,,,Netherlands,Rijkswaterstaat WaterWebservices
+degoudenham.hanzeland,"De Gouden Ham, Hanzeland","De Gouden Ham, Hanzeland",51.826196,5.546664,,,Netherlands,Rijkswaterstaat WaterWebservices
+dehaandrik.beneden,"De Haandrik, beneden","De Haandrik, beneden",52.620952,6.694131,,,Netherlands,Rijkswaterstaat WaterWebservices
+dehaandrik.boven,"De Haandrik, boven","De Haandrik, boven",52.621387,6.695436,,,Netherlands,Rijkswaterstaat WaterWebservices
+dehamert,De Hamert,De Hamert,51.51587,6.152924,,,Netherlands,Rijkswaterstaat WaterWebservices
+dehegegerzen.oudemirdum,"De Hege Gerzen, Oudemirdum","De Hege Gerzen, Oudemirdum",52.833115,5.545044,,,Netherlands,Rijkswaterstaat WaterWebservices
+dehollepoarte.makkum,"De Holle Poarte, Makkum","De Holle Poarte, Makkum",53.052862,5.37802,,,Netherlands,Rijkswaterstaat WaterWebservices
+dehoogewaard.campingbadstrand,"De Hooge Waard, camping badstrand","De Hooge Waard, camping badstrand",51.779529,5.082301,,,Netherlands,Rijkswaterstaat WaterWebservices
+dekoog,De Koog,De Koog,53.103606,4.754129,,,Netherlands,Rijkswaterstaat WaterWebservices
+dekoog.ecomare.badstrand,"De Koog, Ecomare, badstrand","De Koog, Ecomare, badstrand",53.079046,4.732401,,,Netherlands,Rijkswaterstaat WaterWebservices
+dekrim,De Krim,De Krim,53.164407,4.819031,,,Netherlands,Rijkswaterstaat WaterWebservices
+delden.sluis.beneden,"Delden, sluis, beneden","Delden, sluis, beneden",52.2457,6.6754,,,Netherlands,Rijkswaterstaat WaterWebservices
+delden.sluis.boven,"Delden, sluis, boven","Delden, sluis, boven",52.2472,6.6793,,,Netherlands,Rijkswaterstaat WaterWebservices
+delden.sluis.schuif1,"Delden, sluis, schuif 1",boven,52.247067,6.678741,,,Netherlands,Rijkswaterstaat WaterWebservices
+delfzijl,Delfzijl,Delfzijl,53.328,6.931,,,Netherlands,Rijkswaterstaat WaterWebservices
+delfzijl.buitenhaven,"Delfzijl, buitenhaven","Delfzijl, buitenhaven",53.32101,6.964074,,,Netherlands,Rijkswaterstaat WaterWebservices
+delfzijl.oudeeemskanaal.spuisluis,Delfzijl Oude Eemskanaal Spuisluis,Delfzijl Oude Eemskanaal Spuisluis,53.32778,6.92687,,,Netherlands,Rijkswaterstaat WaterWebservices
+demosterdpot,De Mosterdpot,De Mosterdpot,51.81925,5.000435,,,Netherlands,Rijkswaterstaat WaterWebservices
+denhelder.marsdiep,"Den Helder, Marsdiep","Den Helder, Marsdiep",52.964359,4.74499,,,Netherlands,Rijkswaterstaat WaterWebservices
+denhelder.veersteiger,"Den Helder, veersteiger","Den Helder, veersteiger",52.963274,4.778047,,,Netherlands,Rijkswaterstaat WaterWebservices
+denhelder.waddenzee.mondingnieuwehaven,Den Helder Waddenzee Monding Nieuwe Haven,Den Helder Waddenzee Monding Nieuwe Haven,52.967226,4.793579,,,Netherlands,Rijkswaterstaat WaterWebservices
+denhoorntexel.waddenzee.gatvandestier,Den Hoorn Texel Waddenzee Gat van de Stier,Den Hoorn Texel Waddenzee Gat van de Stier,53.0,4.828333,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever,Den Oever,Den Oever,52.934566,5.103875,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.ijsselmeer.binnenhaven,"Den Oever, IJsselmeer binnenhaven","Den Oever, IJsselmeer binnenhaven",52.930195,5.047539,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.ijsselmeer.stevinsluizen.zuid,Den Oever Stevinsluizen zuid,Den Oever Stevinsluizen zuid,52.934036,5.054815,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.ijsselmeer.vaargeul,Den Oever IJsselmeer Vaargeul,Den Oever IJsselmeer Vaargeul,52.90437,5.0807,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.spuisluis.binnen,"Den Oever, spuisluis, binnen",ponton,52.936311,5.052922,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.spuisluizen,"Den Oever, spuisluizen","Den Oever, spuisluizen",52.94281,5.0284,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.waddenzee.voorhaven,"Den Oever, Waddenzee voorhaven","Den Oever, Waddenzee voorhaven",52.931538,5.045596,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.waddenzee.voorhaven.kolk,"Den Oever, Waddenzee voorhaven kolk","Den Oever, Waddenzee voorhaven kolk",52.931652,5.045803,,,Netherlands,Rijkswaterstaat WaterWebservices
+denoever.zuiderhaven.strand,"Den Oever, zuiderhaven, Strand","Den Oever, zuiderhaven, Strand",52.931638,5.039899,,,Netherlands,Rijkswaterstaat WaterWebservices
+denosse,Den Osse,Den Osse,51.745636,3.889908,,,Netherlands,Rijkswaterstaat WaterWebservices
+denossebadstrand,Den Osse badstrand,Den Osse badstrand,51.74417,3.887785,,,Netherlands,Rijkswaterstaat WaterWebservices
+deoudepol,De oude Pol,De oude Pol,52.39283,5.727666,,,Netherlands,Rijkswaterstaat WaterWebservices
+depiet,De Piet,De Piet,51.52142,3.691946,,,Netherlands,Rijkswaterstaat WaterWebservices
+depiet.badstrand,"De Piet, badstrand","De Piet, badstrand",51.530635,3.72634,,,Netherlands,Rijkswaterstaat WaterWebservices
+deral,De Ral,De Ral,52.407309,5.701693,,,Netherlands,Rijkswaterstaat WaterWebservices
+desteeg,De Steeg,De Steeg,52.017067,6.062269,,,Netherlands,Rijkswaterstaat WaterWebservices
+desteeg.haven,"De Steeg, haven","De Steeg, haven",52.01012,6.044835,,,Netherlands,Rijkswaterstaat WaterWebservices
+devechtgrens,De Vechtgrens,De Vechtgrens,52.610495,6.725196,,,Netherlands,Rijkswaterstaat WaterWebservices
+deven,De Ven,De Ven,52.741116,5.2954,,,Netherlands,Rijkswaterstaat WaterWebservices
+deventer,Deventer,Deventer,52.251194,6.153247,,,Netherlands,Rijkswaterstaat WaterWebservices
+deweed,De Weed,De Weed,52.676387,5.268921,,,Netherlands,Rijkswaterstaat WaterWebservices
+dezwaan,De Zwaan,De Zwaan,52.564698,5.833146,,,Netherlands,Rijkswaterstaat WaterWebservices
+diemen,Diemen,Diemen,52.349384,4.983599,,,Netherlands,Rijkswaterstaat WaterWebservices
+diemen.muidenbrug,Diemen Muiden brug,Diemen Muiden brug,52.333141,5.015217,,,Netherlands,Rijkswaterstaat WaterWebservices
+dieren.ijssel,"Dieren, IJssel","Dieren, IJssel",52.049838,6.113642,,,Netherlands,Rijkswaterstaat WaterWebservices
+dinteloord.dintelsas,"Dinteloord, Dintelsas","Dinteloord, Dintelsas",51.659155,4.37668,,,Netherlands,Rijkswaterstaat WaterWebservices
+dinteloord.volkerak,"Dinteloord, Volkerak","Dinteloord, Volkerak",51.65291,4.316483,,,Netherlands,Rijkswaterstaat WaterWebservices
+dinteloord.volkerak.voorheenboeinv3,"Dinteloord, Volkerak, voorheen boei NV3","Dinteloord, Volkerak, voorheen boei NV3",51.652966,4.316622,,,Netherlands,Rijkswaterstaat WaterWebservices
+dirksland,Dirksland,Dirksland,51.79419,4.119528,,,Netherlands,Rijkswaterstaat WaterWebservices
+dodewaard,Dodewaard,Dodewaard,51.900512,5.630518,,,Netherlands,Rijkswaterstaat WaterWebservices
+doekegat,Doekegat,Doekegat,53.466441,6.847737,,,Netherlands,Rijkswaterstaat WaterWebservices
+doesburg,Doesburg,Doesburg,52.012434,6.130079,,,Netherlands,Rijkswaterstaat WaterWebservices
+doesburg.hetzwarteschaar,"Doesburg, Het Zwarte Schaar",Camping IJsselstrand,52.030895,6.159603,,,Netherlands,Rijkswaterstaat WaterWebservices
+doesburg.ijssel,"Doesburg, IJssel","Doesburg, IJssel",52.019532,6.130488,,,Netherlands,Rijkswaterstaat WaterWebservices
+dollard.hoogzand,"Dollard, Hoogzand","Dollard, Hoogzand",53.304653,7.221266,,,Netherlands,Rijkswaterstaat WaterWebservices
+dollard.west,"Dollard, west","Dollard, west",53.279108,7.120344,,,Netherlands,Rijkswaterstaat WaterWebservices
+domburg.badstrand,"Domburg, badstrand","Domburg, badstrand",51.556787,3.473001,,,Netherlands,Rijkswaterstaat WaterWebservices
+dongen.kanaal,Dongen kanaal,Donge aflaatwerk,51.62126,4.92728,,,Netherlands,Rijkswaterstaat WaterWebservices
+doosje,Doosje,Doosje,52.677677,6.136866,,,Netherlands,Rijkswaterstaat WaterWebservices
+doovebalg.midden,"Doove Balg, midden","Doove Balg, midden",53.06092,5.207034,,,Netherlands,Rijkswaterstaat WaterWebservices
+doovebalg.oost,"Doove Balg, oost","Doove Balg, oost",53.084389,5.287214,,,Netherlands,Rijkswaterstaat WaterWebservices
+doovebalg.west,"Doove Balg, west","Doove Balg, west",53.052903,5.032264,,,Netherlands,Rijkswaterstaat WaterWebservices
+dordrecht.dordtschekil,Dordrecht Dordtsche Kil,Dordrecht Dordtsche Kil,51.787782,4.627158,,,Netherlands,Rijkswaterstaat WaterWebservices
+dordrecht.drinkwaterinlaat,"Dordrecht, drinkwaterinlaat","Dordrecht, drinkwaterinlaat",51.808578,4.719611,,,Netherlands,Rijkswaterstaat WaterWebservices
+dordrecht.oudemaas.benedenmerwede,"Dordrecht Oude Maas, Beneden Merwede","Dordrecht Oude Maas, Beneden Merwede",51.82,4.671,,,Netherlands,Rijkswaterstaat WaterWebservices
+dorkwerd.reitdiep,Dorkwerd Reitdiep,vh binnen,53.256512,6.509171,,,Netherlands,Rijkswaterstaat WaterWebservices
+dreischor,Dreischor,Dreischor,51.71462,3.99933,,,Netherlands,Rijkswaterstaat WaterWebservices
+dreischor.gemaal,"Dreischor, gemaal","Dreischor, gemaal",51.708362,4.002272,,,Netherlands,Rijkswaterstaat WaterWebservices
+driel.baggergat,"Driel, baggergat",recreatieplas,51.959428,5.793843,,,Netherlands,Rijkswaterstaat WaterWebservices
+driel.beneden,"Driel, beneden","Driel, beneden",51.962992,5.802606,,,Netherlands,Rijkswaterstaat WaterWebservices
+driel.boven,"Driel, boven","Driel, boven",51.96584,5.810635,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten,Dronten,Dronten,52.542076,5.718131,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten.elburgerweg,"Dronten, Elburgerweg",Hoge Vaart,52.50868,5.765752,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten.reevesluis.drontermeer,Dronten Reevesluis zuid,Dronten Reevesluis zuid,52.5181,5.8575,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten.reevesluis.vossemeer,Dronten Reevesluis noord,Dronten Reevesluis noord,52.5198,5.8575,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten.roggebotsluis.drontermeer,"Dronten, Roggebotsluis, drontermeer",voorheen zuid,52.544491,5.855172,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten.roggebotsluis.spuikoker,"Dronten, Roggebotsluis, spuikoker","Dronten, Roggebotsluis, spuikoker",52.544981,5.856179,,,Netherlands,Rijkswaterstaat WaterWebservices
+dronten.roggebotsluis.vossemeer,"Dronten, Roggebotsluis, Vossemeer",voorheen noord,52.546009,5.855365,,,Netherlands,Rijkswaterstaat WaterWebservices
+drontermeerdijk.km0p4,"Drontermeerdijk, kilometer 0.4","Drontermeerdijk, kilometer 0.4",52.541179,5.856154,,,Netherlands,Rijkswaterstaat WaterWebservices
+dukegat,Dukegat,Dukegat,53.433611,6.926111,,,Netherlands,Rijkswaterstaat WaterWebservices
+dukenburg,Dukenburg,Dukenburg,51.817572,5.811779,,,Netherlands,Rijkswaterstaat WaterWebservices
+durgerdam,Durgerdam,Durgerdam,52.371724,5.012617,,,Netherlands,Rijkswaterstaat WaterWebservices
+echt.kanaal,"Echt, kanaal","Echt, kanaal",51.106196,5.849101,,,Netherlands,Rijkswaterstaat WaterWebservices
+edam,Edam,Edam,52.516051,5.06988,,,Netherlands,Rijkswaterstaat WaterWebservices
+edam.badstrand,"Edam, badstrand","Edam, badstrand",52.51937,5.071123,,,Netherlands,Rijkswaterstaat WaterWebservices
+eefde,Eefde,Eefde,52.159772,6.233957,,,Netherlands,Rijkswaterstaat WaterWebservices
+eefde.sluis.beneden,"Eefde, sluis, beneden","Eefde, sluis, beneden",52.159061,6.22836,,,Netherlands,Rijkswaterstaat WaterWebservices
+eefde.sluis.boven,"Eefde, sluis, boven","Eefde, sluis, boven",52.161,6.238,,,Netherlands,Rijkswaterstaat WaterWebservices
+eekt,Eekt,Eekt,52.481745,5.837828,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemdijk,Eemdijk,Eemdijk,52.261221,5.32236,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemhaven,Eemhaven,Eemhaven,51.889213,4.417595,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemmeerdijk.km23,"Eemmeerdijk, kilometer 23","Eemmeerdijk, kilometer 23",52.278751,5.355114,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemscentrale,Eemscentrale,Eemscentrale,53.443263,6.883823,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemshaven.doekegat,"Eemshaven, Doekegat","Eemshaven, Doekegat",53.45529,6.859522,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemshaven.haven,"Eemshaven, haven","Eemshaven, haven",53.448702,6.828392,,,Netherlands,Rijkswaterstaat WaterWebservices
+eemshaven.waddenzee,"Eemshaven, Waddenzee",stroommeetpaal,53.474392,6.821731,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.10kmuitdekust,"Egmond aan Zee,  10 km uit de kust","Egmond aan Zee,  10 km uit de kust",52.635626,4.47303,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.1kmuitdekust,"Egmond aan Zee,  1 km uit de kust","Egmond aan Zee,  1 km uit de kust",52.620063,4.607176,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.20kmuitdekust,"Egmond aan Zee,  20 km uit de kust","Egmond aan Zee,  20 km uit de kust",52.640914,4.328729,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.2kmuitdekust,"Egmond aan Zee,  2 km uit de kust","Egmond aan Zee,  2 km uit de kust",52.622291,4.594687,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.30kmuitdekust,"Egmond aan Zee,  30 km uit de kust","Egmond aan Zee,  30 km uit de kust",52.667289,4.179745,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.4kmuitdekust,"Egmond aan Zee,  4 km uit de kust","Egmond aan Zee,  4 km uit de kust",52.625624,4.568027,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.50kmuitdekust,"Egmond aan Zee,  50 km uit de kust","Egmond aan Zee,  50 km uit de kust",52.695616,3.886461,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.70kmuitdekust,"Egmond aan Zee,  70 km uit de kust","Egmond aan Zee,  70 km uit de kust",52.728112,3.593174,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondaanzee.badstrand,"Egmond aan Zee, badstrand","Egmond aan Zee, badstrand",52.618502,4.617141,,,Netherlands,Rijkswaterstaat WaterWebservices
+egmondlander,Egmond lander,Egmond lander,52.635,4.6175,,,Netherlands,Rijkswaterstaat WaterWebservices
+eibersburen,Eibersburen,Eibersburen,53.22454,6.11644,,,Netherlands,Rijkswaterstaat WaterWebservices
+eierland,Eierland,Eierland,53.189691,4.798127,,,Netherlands,Rijkswaterstaat WaterWebservices
+eierlandsegat,Eierlandse Gat,Eierlandse Gat,53.2762,4.660347,,,Netherlands,Rijkswaterstaat WaterWebservices
+eijsden,Eijsden,Eijsden,50.7795,5.6987,,,Netherlands,Rijkswaterstaat WaterWebservices
+eijsden.dorp,"Eijsden, dorp","Eijsden, dorp",50.777254,5.699517,,,Netherlands,Rijkswaterstaat WaterWebservices
+eijsden.grens,"Eijsden, grens","Eijsden, grens",50.758,5.682,,,Netherlands,Rijkswaterstaat WaterWebservices
+eindhoven.blaarthem,"Eindhoven, Blaarthem",DM18,51.422066,5.446147,,,Netherlands,Rijkswaterstaat WaterWebservices
+eindhoven.blaarthem.kanaal,Eindhoven Stuw Blaarthem kanaal,Eindhoven Stuw Blaarthem kanaal,51.42181,5.44542,,,Netherlands,Rijkswaterstaat WaterWebservices
+eindhoven.gender,"Eindhoven, Gender",DM17,51.422695,5.446147,,,Netherlands,Rijkswaterstaat WaterWebservices
+eisdenmazenhove.maas,"Eisden Mazenhove, Maas","Eisden Mazenhove, Maas",50.978472,5.735139,,,Netherlands,Rijkswaterstaat WaterWebservices
+eisdenmazenhove.maesbempdergreend,"Eisden Mazenhove, Maesbempder Greend","Eisden Mazenhove, Maesbempder Greend",50.977611,5.735972,,,Netherlands,Rijkswaterstaat WaterWebservices
+elburg.elburgerbrug,Elburg Elburgerbrug,Elburg Elburgerbrug,52.457466,5.817102,,,Netherlands,Rijkswaterstaat WaterWebservices
+elburg.spijkstrand,"Elburg, Spijkstrand","Elburg, Spijkstrand",52.455967,5.811525,,,Netherlands,Rijkswaterstaat WaterWebservices
+ellewoutsdijk,Ellewoutsdijk,Ellewoutsdijk,51.385444,3.817259,,,Netherlands,Rijkswaterstaat WaterWebservices
+elsloo.maas,"Elsloo, Maas","Elsloo, Maas",50.9578,5.7555,,,Netherlands,Rijkswaterstaat WaterWebservices
+emden.vaarwater,"Emden, vaarwater","Emden, vaarwater",53.330825,7.108718,,,Netherlands,Rijkswaterstaat WaterWebservices
+emshornplate,Emshornplate,Emshornplate,53.459425,6.941604,,,Netherlands,Rijkswaterstaat WaterWebservices
+engelsmanplaat,Engelsmanplaat,Engelsmanplaat,53.45392,6.065879,,,Netherlands,Rijkswaterstaat WaterWebservices
+engelsmanplaat.noord,"Engelsmanplaat, noord","Engelsmanplaat, noord",53.463389,6.054827,,,Netherlands,Rijkswaterstaat WaterWebservices
+enkhuizen,Enkhuizen,Enkhuizen,52.699145,5.293268,,,Netherlands,Rijkswaterstaat WaterWebservices
+enkhuizen.ijsselmeer.oost.meetpaal1,"Enkhuizen, IJsselmeer, oost, meetpaal 01",alias FL26,52.721053,5.356702,,,Netherlands,Rijkswaterstaat WaterWebservices
+enkhuizen.ijsselmeer.oost.meetpaal2,"Enkhuizen, IJsselmeer, oost, meetpaal 02",alias FL25,52.721455,5.29849,,,Netherlands,Rijkswaterstaat WaterWebservices
+enkhuizen.strand,"Enkhuizen, strand","Enkhuizen, strand",52.712292,5.292279,,,Netherlands,Rijkswaterstaat WaterWebservices
+enkhuizerzand,Enkhuizerzand,Enkhuizerzand,52.692834,5.416226,,,Netherlands,Rijkswaterstaat WaterWebservices
+enschedevitens,Enschede Vitens,Enschede Vitens,52.236994,6.833485,,,Netherlands,Rijkswaterstaat WaterWebservices
+epen.geul.cottessen,Epen Geul Cottessen,Epen Geul Cottessen,50.75815138,5.934303783,,,Netherlands,Rijkswaterstaat WaterWebservices
+erkemederstrand,Erkemederstrand,Erkemederstrand,52.266946,5.489192,,,Netherlands,Rijkswaterstaat WaterWebservices
+erlecombeneden,Erlecom beneden,Erlecom beneden,51.860731,5.947704,,,Netherlands,Rijkswaterstaat WaterWebservices
+erlecomboven,Erlecom boven,Erlecom boven,51.862612,5.985328,,,Netherlands,Rijkswaterstaat WaterWebservices
+ermelo,Ermelo,Ermelo,52.290938,5.542863,,,Netherlands,Rijkswaterstaat WaterWebservices
+erp.biezenloop,"Erp, Biezenloop","Erp, Biezenloop",51.559931,5.606081,,,Netherlands,Rijkswaterstaat WaterWebservices
+erp.sluis5.beneden,"Erp, sluis 5, beneden","Erp, sluis 5, beneden",51.577442,5.586153,,,Netherlands,Rijkswaterstaat WaterWebservices
+erp.sluis5.boven,"Erp, sluis 5, boven","Erp, sluis 5, boven",51.576461,5.587317,,,Netherlands,Rijkswaterstaat WaterWebservices
+erp.sluis5.inlaat,"Erp, Sluis 5, inlaat",Spuien,51.577511,5.58585,,,Netherlands,Rijkswaterstaat WaterWebservices
+erp.sluis5.uitlaat,"Erp, Sluis 5, uitlaat",NettobalansUIT,51.577506,5.58585,,,Netherlands,Rijkswaterstaat WaterWebservices
+europahaven,Europahaven,Europahaven,51.962179,4.029151,,,Netherlands,Rijkswaterstaat WaterWebservices
+europlatform,Europlatform,Europlatform,51.99781,3.275071,,,Netherlands,Rijkswaterstaat WaterWebservices
+europoort.harmsenbrug,"Europoort, Harmsenbrug","Europoort, Harmsenbrug",51.901771,4.210879,,,Netherlands,Rijkswaterstaat WaterWebservices
+europoort.hartelbrug,"Europoort, Hartelbrug","Europoort, Hartelbrug",51.86635,4.307781,,,Netherlands,Rijkswaterstaat WaterWebservices
+europoort.hartelkering,"Europoort, Hartelkering","Europoort, Hartelkering",51.864941,4.307118,,,Netherlands,Rijkswaterstaat WaterWebservices
+f16,F16,platform,54.116667,4.012222,,,Netherlands,Rijkswaterstaat WaterWebservices
+f3,F3,platform,54.853199,4.726133,,,Netherlands,Rijkswaterstaat WaterWebservices
+flakkeesespuisluis.meerzijde,"Flakkeese spuisluis, meerzijde","Flakkeese spuisluis, meerzijde",51.679195,4.150379,,,Netherlands,Rijkswaterstaat WaterWebservices
+flevocentrale,Flevocentrale,Flevocentrale,52.580206,5.522936,,,Netherlands,Rijkswaterstaat WaterWebservices
+fortcrevecoeur,Fort Crevecoeur,monding van de Dieze,51.733567,5.269946,,,Netherlands,Rijkswaterstaat WaterWebservices
+fortliefkenshoek,Fort Liefkenshoek,Fort Liefkenshoek,51.296459,4.285749,,,Netherlands,Rijkswaterstaat WaterWebservices
+friesekust.ijsselmeer,Friesekust IJsselmeer,Friesekust IJsselmeer,52.822278,5.478778,,,Netherlands,Rijkswaterstaat WaterWebservices
+gaatjebocht.noord,"Gaatje Bocht, noord","Gaatje Bocht, noord",53.327952,7.022947,,,Netherlands,Rijkswaterstaat WaterWebservices
+gaatjebocht.noordwest,"Gaatje Bocht, noordwest","Gaatje Bocht, noordwest",53.322732,7.014944,,,Netherlands,Rijkswaterstaat WaterWebservices
+gaatjebocht.west,"Gaatje Bocht, west","Gaatje Bocht, west",53.319336,7.015491,,,Netherlands,Rijkswaterstaat WaterWebservices
+galatheahaven,Galathea haven,Galathea haven,51.659493,4.313728,,,Netherlands,Rijkswaterstaat WaterWebservices
+gammels,Gammels,Gammels,52.876619,5.152524,,,Netherlands,Rijkswaterstaat WaterWebservices
+gatvanborssele,Gat van Borssele,Gat van Borssele,51.411393,3.757884,,,Netherlands,Rijkswaterstaat WaterWebservices
+gatvandekerksloot.badstrand,"Gat van de Kerksloot, badstrand","Gat van de Kerksloot, badstrand",51.724368,4.771368,,,Netherlands,Rijkswaterstaat WaterWebservices
+gatvandevloeien.badstrand,"Gat van de Vloeien, badstrand","Gat van de Vloeien, badstrand",51.732889,4.785293,,,Netherlands,Rijkswaterstaat WaterWebservices
+gatvanschiermonnikoog,Gat van Schiermonnikoog,Gat van Schiermonnikoog,53.442927,6.126113,,,Netherlands,Rijkswaterstaat WaterWebservices
+geersdijk,Geersdijk,Geersdijk,51.553344,3.762139,,,Netherlands,Rijkswaterstaat WaterWebservices
+geertruidenbergamercentrale,Geertruidenberg Amercentrale,Geertruidenberg Amercentrale,51.715496,4.849919,,,Netherlands,Rijkswaterstaat WaterWebservices
+geisedam,Geisedam,Geisedam,53.320654,7.129204,,,Netherlands,Rijkswaterstaat WaterWebservices
+gelresend.noordzijde,"Gelre's End, noordzIJde","Gelre's End, noordzIJde",51.73985,5.261243,,,Netherlands,Rijkswaterstaat WaterWebservices
+genemuiden,Genemuiden,de ketting,52.633395,6.033154,,,Netherlands,Rijkswaterstaat WaterWebservices
+genemuiden.veer,"Genemuiden, veer","Genemuiden, veer",52.629275,6.038557,,,Netherlands,Rijkswaterstaat WaterWebservices
+gennep,Gennep,Gennep,51.697,5.9574,,,Netherlands,Rijkswaterstaat WaterWebservices
+glimmen.depunt,"Glimmen, De Punt",Drentse Aa,53.131292,6.619242,,,Netherlands,Rijkswaterstaat WaterWebservices
+goedereede,Goedereede,Goedereede,51.840963,3.965108,,,Netherlands,Rijkswaterstaat WaterWebservices
+goedereede.noordzee.meetpaal,"Goedereede, Noordzee, meetpaal","Goedereede, Noordzee, meetpaal",51.867868,3.959901,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree.lichteiland,"Goeree, lichteiland","Goeree, lichteiland",51.925034,3.668416,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree10kmuitdekust,Goeree 10 km uit de kust,Goeree 10 km uit de kust,51.894884,3.828948,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree20kmuitdekust,Goeree 20 km uit de kust,Goeree 20 km uit de kust,51.953368,3.720361,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree2kmuitdekust,Goeree 2 km uit de kust,Goeree 2 km uit de kust,51.846089,3.915502,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree30kmuitdekust,Goeree 30 km uit de kust,Goeree 30 km uit de kust,52.014308,3.612317,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree50kmuitdekust,Goeree 50 km uit de kust,Goeree 50 km uit de kust,52.135037,3.396881,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree6kmuitdekust,Goeree 6 km uit de kust,Goeree 6 km uit de kust,51.868923,3.872311,,,Netherlands,Rijkswaterstaat WaterWebservices
+goeree70kmuitdekust,Goeree 70 km uit de kust,Goeree 70 km uit de kust,52.251431,3.181178,,,Netherlands,Rijkswaterstaat WaterWebservices
+goesschesas,Goessche Sas,Goessche Sas,51.538629,3.927729,,,Netherlands,Rijkswaterstaat WaterWebservices
+goidschalxoord.oudemaas.meetboeiom1,"Goidschalxoord, Oude Maas, meetboei OM1",km 993.560,51.830749,4.455269,,,Netherlands,Rijkswaterstaat WaterWebservices
+gooierhoofdzomerkade,Gooierhoofd zomerkade,Gooierhoofd zomerkade,52.30578,5.25548,,,Netherlands,Rijkswaterstaat WaterWebservices
+gooimeer.midden,"Gooimeer, midden","Gooimeer, midden",52.322875,5.196802,,,Netherlands,Rijkswaterstaat WaterWebservices
+gooiseweg,Gooiseweg,Hoge Vaart,52.410234,5.598836,,,Netherlands,Rijkswaterstaat WaterWebservices
+gorinchem,Gorinchem,Gorinchem,51.826922,4.97552,,,Netherlands,Rijkswaterstaat WaterWebservices
+gorinchembinnen,Gorinchem binnen,Gorinchem binnen,51.836716,4.974415,,,Netherlands,Rijkswaterstaat WaterWebservices
+gorishoek,Gorishoek,Gorishoek,51.524986,4.081504,,,Netherlands,Rijkswaterstaat WaterWebservices
+gouda,Gouda,Gouda,52.00538,4.711439,,,Netherlands,Rijkswaterstaat WaterWebservices
+gouda.hanepraaisluis,"Gouda, Hanepraaisluis","Gouda, Hanepraaisluis",52.007193,4.714179,,,Netherlands,Rijkswaterstaat WaterWebservices
+gouda.hollandscheijssel,Gouda Hollandsche IJssel,Gouda Hollandsche IJssel,52.00658,4.71972,,,Netherlands,Rijkswaterstaat WaterWebservices
+gouda.voorhaven,"Gouda, voorhaven","Gouda, voorhaven",51.996723,4.691184,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudenham,Gouden Ham,recreatieplas,51.836883,5.546804,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudenham.beneden.overlaat,"Gouden Ham, beneden, overlaat","Gouden Ham, beneden, overlaat",51.831515,5.568123,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudenham.hanzebad,"Gouden Ham, hanzebad",recreatieplas,51.827532,5.548947,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudenham.instroming,"Gouden Ham, instroming",recreatieplas,51.821876,5.544575,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudenham.maaslanden,"Gouden Ham, Maaslanden",recreatieplas,51.829945,5.558747,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudenham.molenstrand,"Gouden Ham, Molenstrand","Gouden Ham, Molenstrand",51.838168,5.547011,,,Netherlands,Rijkswaterstaat WaterWebservices
+gouderak,Gouderak,Gouderak,51.985555,4.672432,,,Netherlands,Rijkswaterstaat WaterWebservices
+goudswaard.spui,"Goudswaard, Spui","Goudswaard, Spui",51.782319,4.236792,,,Netherlands,Rijkswaterstaat WaterWebservices
+grave.beneden,"Grave, beneden",sluis,51.775,5.72,,,Netherlands,Rijkswaterstaat WaterWebservices
+grave.boven,"Grave, boven",sluis,51.761,5.743,,,Netherlands,Rijkswaterstaat WaterWebservices
+gravenbol,Gravenbol,Gravenbol,51.971816,5.385602,,,Netherlands,Rijkswaterstaat WaterWebservices
+grevelingendam.badstrand,"Grevelingendam, badstrand","Grevelingendam, badstrand",51.679557,4.117824,,,Netherlands,Rijkswaterstaat WaterWebservices
+grevelingendam.plaatvanoudetonge.badstrand,"Grevelingendam, Plaat van Oude Tonge, badstrand","Grevelingendam, Plaat van Oude Tonge, badstrand",51.676206,4.140619,,,Netherlands,Rijkswaterstaat WaterWebservices
+grevelingenmeer.hals,"Grevelingen Meer, Hals","Grevelingen Meer, Hals",51.756406,4.013255,,,Netherlands,Rijkswaterstaat WaterWebservices
+grevenbicht,Grevenbicht,Grevenbicht,51.041418,5.765753,,,Netherlands,Rijkswaterstaat WaterWebservices
+grijpskerk.gaarkeuken.oost,Grijpskerk Gaarkeuken oost,Grijpskerk Gaarkeuken oost,53.24909,6.317575,,,Netherlands,Rijkswaterstaat WaterWebservices
+grijpskerk.gaarkeuken.west,Grijpskerk Gaarkeuken west,Grijpskerk Gaarkeuken west,53.247767,6.305834,,,Netherlands,Rijkswaterstaat WaterWebservices
+groenendijk,Groenendijk,Donge,51.673353,4.915909,,,Netherlands,Rijkswaterstaat WaterWebservices
+groenevaart.beneden,"Groene vaart, beneden","Groene vaart, beneden",52.158543,6.232977,,,Netherlands,Rijkswaterstaat WaterWebservices
+groenevaart.boven,"Groene vaart, boven","Groene vaart, boven",52.158552,6.232991,,,Netherlands,Rijkswaterstaat WaterWebservices
+groningen,Groningen,Groningen,53.228119,6.591879,,,Netherlands,Rijkswaterstaat WaterWebservices
+groningerwad,Groninger Wad,Groninger Wad,53.450767,6.406221,,,Netherlands,Rijkswaterstaat WaterWebservices
+grootammers.veerstoep.badstrand,"Groot Ammers, Veerstoep, badstrand","Groot Ammers, Veerstoep, badstrand",51.917449,4.786617,,,Netherlands,Rijkswaterstaat WaterWebservices
+grootegat.noord,"Groote Gat, noord","Groote Gat, noord",53.304291,7.15666,,,Netherlands,Rijkswaterstaat WaterWebservices
+grootegat.zuid,"Groote Gat, zuid","Groote Gat, zuid",53.277784,7.163639,,,Netherlands,Rijkswaterstaat WaterWebservices
+grootekeeten,Groote Keeten,Groote Keeten,52.864543,4.701166,,,Netherlands,Rijkswaterstaat WaterWebservices
+grotevlak,Grote Vlak,Grote Vlak,53.025892,4.708013,,,Netherlands,Rijkswaterstaat WaterWebservices
+haandrik.kruising.overijssels.kan.km2.3,Haandrik Kruising Overijssels kan.(km 2.3),Haandrik Kruising Overijssels kan.(km 2.3),52.62083255,6.698484616,,,Netherlands,Rijkswaterstaat WaterWebservices
+haastrecht,Haastrecht,Haastrecht,52.002122,4.773018,,,Netherlands,Rijkswaterstaat WaterWebservices
+hagestein,Hagestein,Hagestein,51.990866,5.132711,,,Netherlands,Rijkswaterstaat WaterWebservices
+hagestein.beneden,"Hagestein, beneden","Hagestein, beneden",51.993,5.1315,,,Netherlands,Rijkswaterstaat WaterWebservices
+hagestein.boven,"Hagestein, boven","Hagestein, boven",51.9895,5.1352,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst,Haghorst,Haghorst,51.498346,5.207331,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.beneden,"Haghorst, sluis 4, beneden","Haghorst, sluis 4, beneden",51.498158,5.206136,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.boven,"Haghorst, sluis 4, boven","Haghorst, sluis 4, boven",51.498219,5.207719,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.inlaat,"Haghorst, Sluis 4, inlaat",Spuien,51.498236,5.207722,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.kolk,Haghorst Sluis 4 kolk,Haghorst Sluis 4 kolk,51.49823098,5.20772101,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.schuif,Haghorst Sluis 4 schuif,Haghorst Sluis 4 schuif,51.49823098,5.20772101,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.schuif1,"Haghorst, sluis 4, schuif1","Haghorst, sluis 4, schuif1",51.497942,5.207447,,,Netherlands,Rijkswaterstaat WaterWebservices
+haghorst.sluis4.uitlaat,"Haghorst, Sluis 4, uitlaat",NettobalansUIT,51.498231,5.207722,,,Netherlands,Rijkswaterstaat WaterWebservices
+hammen.boeih16.plompetoren,"Hammen, boei H16, Plompetoren","Hammen, boei H16, Plompetoren",51.677231,3.775405,,,Netherlands,Rijkswaterstaat WaterWebservices
+hammen.boeih2,"Hammen, boei H2","Hammen, boei H2",51.654389,3.855132,,,Netherlands,Rijkswaterstaat WaterWebservices
+hammen.boeih9.gemaal,"Hammen, boei H9, Gemaal","Hammen, boei H9, Gemaal",51.675345,3.859339,,,Netherlands,Rijkswaterstaat WaterWebservices
+hammen.oost,"Hammen, oost","Hammen, oost",51.6602,3.852695,,,Netherlands,Rijkswaterstaat WaterWebservices
+hammen.west,"Hammen, west","Hammen, west",51.672004,3.754988,,,Netherlands,Rijkswaterstaat WaterWebservices
+hank,Hank,Hank,51.717219,4.849319,,,Netherlands,Rijkswaterstaat WaterWebservices
+hank.bergschemaas,"Hank, Bergsche Maas",voorheen Keizersveer,51.7191,4.894,,,Netherlands,Rijkswaterstaat WaterWebservices
+hansweert,Hansweert,Hansweert,51.44567,3.99744,,,Netherlands,Rijkswaterstaat WaterWebservices
+hansweert.boeiohmg,"Hansweert, boei OHMG","Hansweert, boei OHMG",51.440034,3.990671,,,Netherlands,Rijkswaterstaat WaterWebservices
+hansweert.geul,"Hansweert, geul","Hansweert, geul",51.436114,4.014149,,,Netherlands,Rijkswaterstaat WaterWebservices
+hardenberg.beneden,"Hardenberg, beneden","Hardenberg, beneden",52.566382,6.61747,,,Netherlands,Rijkswaterstaat WaterWebservices
+hardenberg.boven,"Hardenberg, boven","Hardenberg, boven",52.567067,6.616383,,,Netherlands,Rijkswaterstaat WaterWebservices
+hardersluis.noord,"Hardersluis, noord","Hardersluis, noord",52.365179,5.613523,,,Netherlands,Rijkswaterstaat WaterWebservices
+hardersluis.zuid,"Hardersluis, zuid","Hardersluis, zuid",52.364463,5.612198,,,Netherlands,Rijkswaterstaat WaterWebservices
+harderwijk.ijsselmeer,"Harderwijk, IJsselmeer",voorheen Harderhaven buiten,52.367957,5.617722,,,Netherlands,Rijkswaterstaat WaterWebservices
+harderwijk.veluwestrand.1,"Harderwijk, Veluwestrand, 1","Harderwijk, Veluwestrand, 1",52.355371,5.61478,,,Netherlands,Rijkswaterstaat WaterWebservices
+hardinxveld,Hardinxveld,kilometer 962,51.815838,4.876714,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.1,"Haringvliet, Kier1","Haringvliet, Kier1",51.816399,4.093623,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.10,"Haringvliet, punt 10","Haringvliet, punt 10",51.862779,3.860561,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.2,"Haringvliet, Kier2","Haringvliet, Kier2",51.754546,4.240773,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.20,"Haringvliet, 20","Haringvliet, 20",51.721629,4.394648,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.21,"Haringvliet, 21","Haringvliet, 21",51.726518,4.382874,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.22,"Haringvliet, 22","Haringvliet, 22",51.731954,4.371114,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.23,"Haringvliet, 23","Haringvliet, 23",51.73747,4.357381,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.24,"Haringvliet, 24","Haringvliet, 24",51.742332,4.343036,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.25,"Haringvliet, 25","Haringvliet, 25",51.745663,4.329564,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.26,"Haringvliet, 26","Haringvliet, 26",51.749382,4.316371,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.27,"Haringvliet, 27","Haringvliet, 27",51.752276,4.302645,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.28,"Haringvliet, 28","Haringvliet, 28",51.755728,4.289149,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.29,"Haringvliet, 29","Haringvliet, 29",51.756669,4.274584,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.3,"Haringvliet, Kier3","Haringvliet, Kier3",51.725646,4.375512,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.30,"Haringvliet, 30","Haringvliet, 30",51.758575,4.260428,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.31,"Haringvliet, 31","Haringvliet, 31",51.759901,4.248807,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.4,"Haringvliet, Kier4","Haringvliet, Kier4",51.726,4.364576,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.44,"Haringvliet, 44","Haringvliet, 44",51.777648,4.195639,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.45,"Haringvliet, 45","Haringvliet, 45",51.767118,4.205059,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.46,"Haringvliet, 46","Haringvliet, 46",51.761335,4.216466,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.47,"Haringvliet, 47","Haringvliet, 47",51.756203,4.229158,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.49,"Haringvliet, 49","Haringvliet, 49",51.765964,4.225416,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.50,"Haringvliet, 50","Haringvliet, 50",51.771243,4.213007,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.51,"Haringvliet, 51","Haringvliet, 51",51.778229,4.198029,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.52,"Haringvliet, 52","Haringvliet, 52",51.800675,4.185621,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.53,"Haringvliet, 53","Haringvliet, 53",51.803418,4.178791,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvliet.ponton.2,"Haringvliet, ponton, 2",kier,51.82,4.074,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietbrug,Haringvlietbrug,Haringvlietbrug,51.712529,4.395311,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietbrug.1,"Haringvlietbrug, 1","Haringvlietbrug, 1",51.719335,4.402861,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietbrug.oost,"Haringvlietbrug, oost","Haringvlietbrug, oost",51.722137,4.406882,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietbrug.west,"Haringvlietbrug, west","Haringvlietbrug, west",51.722033,4.403063,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietmond,Haringvlietmond,Haringvlietmond,51.895597,3.933201,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietsluizen,Haringvlietsluizen,punt ligt binnen,51.82947,4.058326,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietsluizen.1km.noordwest,"Haringvlietsluizen, 1 km, noordwest","Haringvlietsluizen, 1 km, noordwest",51.850039,4.044162,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietsluizen.binnen,"Haringvlietsluizen, binnen","Haringvlietsluizen, binnen",51.835994,4.054941,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietsluizen.binnen.noord,"Haringvlietsluizen, binnen, noord","Haringvlietsluizen, binnen, noord",51.837574,4.059538,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietsluizen.binnen.zuid,"Haringvlietsluizen, binnen, zuid","Haringvlietsluizen, binnen, zuid",51.82576,4.04828,,,Netherlands,Rijkswaterstaat WaterWebservices
+haringvlietsluizen.buiten,"Haringvlietsluizen, buiten","Haringvlietsluizen, buiten",51.829227,4.04484,,,Netherlands,Rijkswaterstaat WaterWebservices
+harlingen.harlingerstrand,"Harlingen, Harlingerstrand","Harlingen, Harlingerstrand",53.166818,5.414661,,,Netherlands,Rijkswaterstaat WaterWebservices
+harlingen.havenmond.west,"Harlingen, havenmond, west","Harlingen, havenmond, west",53.176984,5.396929,,,Netherlands,Rijkswaterstaat WaterWebservices
+harlingen.vaargeul,"Harlingen, vaargeul","Harlingen, vaargeul",53.194492,5.328854,,,Netherlands,Rijkswaterstaat WaterWebservices
+harlingen.voorhaven,"Harlingen, voorhaven","Harlingen, voorhaven",53.174287,5.405902,,,Netherlands,Rijkswaterstaat WaterWebservices
+harlingen.waddenzee,"Harlingen, Waddenzee","Harlingen, Waddenzee",53.175634,5.409342,,,Netherlands,Rijkswaterstaat WaterWebservices
+hartelkanaal.kuwaitpetroleum,"Hartelkanaal, Kuwait Petroleum","Hartelkanaal, Kuwait Petroleum",51.930255,4.163079,,,Netherlands,Rijkswaterstaat WaterWebservices
+hartelkering.landzijde,"Hartelkering, Landzijde","Hartelkering, Landzijde",51.866517,4.313064,,,Netherlands,Rijkswaterstaat WaterWebservices
+hartelkering.zeezijde,"Hartelkering, Zeezijde","Hartelkering, Zeezijde",51.867144,4.3012,,,Netherlands,Rijkswaterstaat WaterWebservices
+hasselt,Hasselt,Hasselt,52.589725,6.086965,,,Netherlands,Rijkswaterstaat WaterWebservices
+hasselt.zwartewater,"Hasselt, Zwarte Water",voorheen Mond der Vecht,52.564026,6.101306,,,Netherlands,Rijkswaterstaat WaterWebservices
+hato.kayatilburg,Hato Kaya Tilburg,Hato Kaya Tilburg,12.17712,-68.292651,,,Netherlands,Rijkswaterstaat WaterWebservices
+hato.marinakralendijk,Hato Marina Kralendijk,Hato Marina Kralendijk,12.167587,-68.28753,,,Netherlands,Rijkswaterstaat WaterWebservices
+hedel,Hedel,Hedel,51.738778,5.267761,,,Netherlands,Rijkswaterstaat WaterWebservices
+hedel.recreatieplas,"Hedel, recreatieplas","Hedel, recreatieplas",51.738948,5.25835,,,Netherlands,Rijkswaterstaat WaterWebservices
+heel.kanaal,"Heel, kanaal",boven,51.1743,5.918,,,Netherlands,Rijkswaterstaat WaterWebservices
+heel.lateraalkanaallinnebuggenum.innamewerk,"Heel, Lateraal Kanaal Linne-Buggenum, innamewerk","Heel, Lateraal Kanaal Linne-Buggenum, innamewerk",51.187568,5.92716,,,Netherlands,Rijkswaterstaat WaterWebservices
+heel.maas,"Heel, Maas",beneden,51.1765,5.9195,,,Netherlands,Rijkswaterstaat WaterWebservices
+heerewaarden.kampeerterrein,"Heerewaarden, kampeerterrein",recreatieplas,51.814071,5.395178,,,Netherlands,Rijkswaterstaat WaterWebservices
+heerewaarden.ontzanding,"Heerewaarden, ontzanding",recreatieplas,51.79924,5.37488,,,Netherlands,Rijkswaterstaat WaterWebservices
+heesbeen,Heesbeen,Heesbeen,51.735848,5.124738,,,Netherlands,Rijkswaterstaat WaterWebservices
+heeswijksekampen,Heeswijkse Kampen,Heeswijkse Kampen,51.74776,5.849381,,,Netherlands,Rijkswaterstaat WaterWebservices
+heinenoord,Heinenoord,kilometer 993.5,51.831949,4.455795,,,Netherlands,Rijkswaterstaat WaterWebservices
+heinenoord.goidschalxoord,"Heinenoord, Goidschalxoord","Heinenoord, Goidschalxoord",51.830298,4.451622,,,Netherlands,Rijkswaterstaat WaterWebservices
+hellegat,Hellegat,Hellegat,51.697203,4.390006,,,Netherlands,Rijkswaterstaat WaterWebservices
+hellevloetsluis.hellecat.badstrand,"Hellevloetsluis, Hellecat, badstrand","Hellevloetsluis, Hellecat, badstrand",51.841339,4.07616,,,Netherlands,Rijkswaterstaat WaterWebservices
+hellevoetsluis,Hellevoetsluis,Hellevoetsluis,51.819724,4.128239,,,Netherlands,Rijkswaterstaat WaterWebservices
+hellevoetsluis.schenkeldijk.badstrand,"Hellevoetsluis, Schenkeldijk, badstrand","Hellevoetsluis, Schenkeldijk, badstrand",51.829859,4.093135,,,Netherlands,Rijkswaterstaat WaterWebservices
+hellevoetsluis.vuurtorengroot.badstrand,"Hellevoetsluis, Vuurtoren Groot, badstrand","Hellevoetsluis, Vuurtoren Groot, badstrand",51.82151,4.124693,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.aflaat,Helmond RWZI aflaatwerk,Helmond RWZI aflaatwerk,51.499525,5.674439,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.aflaat.boven,"Helmond, aflaat, boven",voorheen waterzuivering,51.499374,5.673257,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.devries,"Helmond, De Vries",AA26,51.487541,5.652061,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.ehkgoorloop.pomp,"Helmond, EHK-Goorloop, pomp",AA23B,51.456646,5.656389,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.guldenaa,"Helmond, Gulden Aa","Helmond, Gulden Aa",51.490731,5.6522,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.guldenaa.a,"Helmond, Gulden Aa, A","Helmond, Gulden Aa, A",51.490731,5.652203,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.guldenaa.b,"Helmond, Gulden Aa, B","Helmond, Gulden Aa, B",51.490731,5.652206,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.scheepstal,Helmond stuw Scheepstal inlaat,Helmond stuw Scheepstal inlaat,51.498736,5.684486,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.schotenseloop,"Helmond, Schotense Loop","Helmond, Schotense Loop",51.448431,5.607669,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.sluis.aflaat1,"Helmond, sluis, aflaat 1",voorheen Vossebeemd,51.46883,5.69194,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.sluis.boven,"Helmond, sluis, boven","Helmond, sluis, boven",51.44851,5.693609,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.sluis7,Helmond ZuidWillemsvaart Sluis 7,Helmond ZuidWillemsvaart Sluis 7,51.496306,5.652271,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.sluis9.inlaat,"Helmond, Sluis 9, inlaat",Spuien,51.447633,5.684497,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.sluis9.uitlaat,"Helmond, Sluis 9, uitlaat",NettobalansUIT,51.447636,5.684497,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.spaarpand,"Helmond, spaarpand","Helmond, spaarpand",51.512634,5.661485,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.traverse.sluis7,"Helmond, traverse, sluis 7","Helmond, traverse, sluis 7",51.496026,5.652168,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.treverse.sluis9,"Helmond, treverse, sluis 9","Helmond, treverse, sluis 9",51.447782,5.426041,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart,"Helmond, Zuid-Willemsvaart",De Vries,51.486981,5.652061,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart.inlaatnieuweaa,"Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa",nettobalansuit,51.465297,5.693592,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart.inlaatnieuweaa.inlaat,"Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa, inlaat",schutten,51.465306,5.693592,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart.inlaatnieuweaa.kleplinks,"Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa, klep links","Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa, klep links",51.465303,5.693592,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart.inlaatnieuweaa.kleprechts,"Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa, klep rechts","Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa, klep rechts",51.4653,5.693592,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart.inlaatnieuweaa.uitlaat,"Helmond, Zuid-Willemsvaart, inlaat Nieuwe Aa, uitlaat",spuien,51.465308,5.693592,,,Netherlands,Rijkswaterstaat WaterWebservices
+helmond.zuidwillemsvaart.instroomaa,"Helmond, Zuid-Willemsvaart, instroom Aa","Helmond, Zuid-Willemsvaart, instroom Aa",51.499622,5.674581,,,Netherlands,Rijkswaterstaat WaterWebservices
+helsdeur,Helsdeur,Helsdeur,52.96232,4.750229,,,Netherlands,Rijkswaterstaat WaterWebservices
+hemelrijksewaard.dagstrand,"Hemelrijkse Waard, dagstrand","Hemelrijkse Waard, dagstrand",51.799553,5.481898,,,Netherlands,Rijkswaterstaat WaterWebservices
+hengelo.koppelleiding,"Hengelo, Koppelleiding","Hengelo, Koppelleiding",52.246826,6.801732,,,Netherlands,Rijkswaterstaat WaterWebservices
+hengelo.oelerbrug,"Hengelo, Oelerbrug",km 42.6,52.25037,6.76734,,,Netherlands,Rijkswaterstaat WaterWebservices
+hengelo.sluis.beneden,"Hengelo, sluis, beneden","Hengelo, sluis, beneden",52.2464,6.802,,,Netherlands,Rijkswaterstaat WaterWebservices
+hengelo.sluis.boven,"Hengelo, sluis, boven","Hengelo, sluis, boven",52.2459,6.8064,,,Netherlands,Rijkswaterstaat WaterWebservices
+herenlaak,Herenlaak,Herenlaak,51.101167,5.81875,,,Netherlands,Rijkswaterstaat WaterWebservices
+herkingen,Herkingen,Herkingen,51.690479,4.089169,,,Netherlands,Rijkswaterstaat WaterWebservices
+herkingenbadstrand,Herkingen badstrand,Herkingen badstrand,51.707915,4.08071,,,Netherlands,Rijkswaterstaat WaterWebservices
+herwijnen,Herwijnen,Herwijnen,51.826765,5.104771,,,Netherlands,Rijkswaterstaat WaterWebservices
+hetwild.raai212,"Het Wild, raai 212",recreatieplas,51.768226,5.352433,,,Netherlands,Rijkswaterstaat WaterWebservices
+hetzwinduinlaanbadstrand,het Zwin Duinlaan badstrand,het Zwin Duinlaan badstrand,51.373156,3.370986,,,Netherlands,Rijkswaterstaat WaterWebservices
+heusden,Heusden,Heusden,51.735688,5.133425,,,Netherlands,Rijkswaterstaat WaterWebservices
+heusden.bernseveer,"Heusden, Bernse Veer","Heusden, Bernse Veer",51.743865,5.163192,,,Netherlands,Rijkswaterstaat WaterWebservices
+hindeloopen,Hindeloopen,Hindeloopen,52.9703,5.345528,,,Netherlands,Rijkswaterstaat WaterWebservices
+hindeloopen.badpaviljoenhindeloopen,"Hindeloopen, Badpaviljoen Hindeloopen","Hindeloopen, Badpaviljoen Hindeloopen",52.933444,5.403328,,,Netherlands,Rijkswaterstaat WaterWebservices
+hitsertsekade.badstrand,"Hitsertse kade, badstrand","Hitsertse kade, badstrand",51.736514,4.368333,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoedekenskerke,Hoedekenskerke,Hoedekenskerke,51.418648,3.916187,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoedekenskerke.boei4,"Hoedekenskerke, boei 4","Hoedekenskerke, boei 4",51.425087,3.920581,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanbaarlandboei29,Hoek van Baarland boei 29,Hoek van Baarland boei 29,51.378961,3.91287,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland,Hoek van Holland,rechter oever kilometer 1030.1,51.976899,4.119827,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.badstrand,"Hoek van Holland, badstrand",meteo,51.986252,4.097826,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.benoordendenoorderdam,"Hoek van Holland, benoorden de Noorderdam",Dk1,51.998359,4.078138,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.maeslantkering.beneden.noord,"Hoek van Holland, Maeslantkering, Beneden, noord",zeezijde,51.958239,4.161443,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.midden,"Hoek van Holland, midden","Hoek van Holland, midden",51.977917,4.109973,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.noordoever,"Hoek van Holland, noordoever","Hoek van Holland, noordoever",51.976573,4.110448,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.splitsingsdam,"Hoek van Holland, splitsingsdam","Hoek van Holland, splitsingsdam",51.972365,4.116127,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoekvanholland.zuidoever,"Hoek van Holland, zuidoever","Hoek van Holland, zuidoever",51.97928,4.11139,,,Netherlands,Rijkswaterstaat WaterWebservices
+hogeknarsluis.hogevaart,"Hoge Knarsluis, Hoge Vaart","Hoge Knarsluis, Hoge Vaart",52.384265,5.537022,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.1.holldp1,"Hollandsch Diep, 1, HOLLDP1","Hollandsch Diep, 1, HOLLDP1",51.720847,4.641801,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.10,"Hollandsch Diep, 10","Hollandsch Diep, 10",51.69024,4.530161,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.11,"Hollandsch Diep, 11","Hollandsch Diep, 11",51.690173,4.515005,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.12,"Hollandsch Diep, 12","Hollandsch Diep, 12",51.692226,4.499923,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.13,"Hollandsch Diep, 13","Hollandsch Diep, 13",51.691174,4.48457,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.14,"Hollandsch Diep, 14","Hollandsch Diep, 14",51.69232,4.468926,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.15,"Hollandsch Diep, 15","Hollandsch Diep, 15",51.69562,4.455436,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.16,"Hollandsch Diep, 16","Hollandsch Diep, 16",51.698495,4.441736,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.17,"Hollandsch Diep, 17","Hollandsch Diep, 17",51.702271,4.428564,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.18,"Hollandsch Diep, 18","Hollandsch Diep, 18",51.71436,4.42074,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.19,"Hollandsch Diep, 19","Hollandsch Diep, 19",51.717564,4.40714,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.2.holldp2,"Hollandsch Diep, 2, HOLLDP2","Hollandsch Diep, 2, HOLLDP2",51.721359,4.637566,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.3,"Hollandsch Diep, 3","Hollandsch Diep, 3",51.717975,4.621631,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.4,"Hollandsch Diep, 4","Hollandsch Diep, 4",51.707558,4.613619,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.5,"Hollandsch Diep, 5","Hollandsch Diep, 5",51.700468,4.603078,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.6,"Hollandsch Diep, 6","Hollandsch Diep, 6",51.695748,4.588421,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.7,"Hollandsch Diep, 7","Hollandsch Diep, 7",51.69396,4.574148,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.8,"Hollandsch Diep, 8","Hollandsch Diep, 8",51.692252,4.559932,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.9,"Hollandsch Diep, 9","Hollandsch Diep, 9",51.691022,4.545043,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandschdiep.monddordtschekil.west,"Hollandsch Diep, mond Dordtsche Kil, west","Hollandsch Diep, mond Dordtsche Kil, west",51.711725,4.606226,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.0,"Hollandsche IJssel, 0","Hollandsche IJssel, 0",52.008971,4.726533,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.1,"Hollandsche IJssel, 1","Hollandsche IJssel, 1",52.006863,4.717782,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.10,"Hollandsche IJssel, 10","Hollandsche IJssel, 10",51.960758,4.641021,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.11,"Hollandsche IJssel, 11","Hollandsche IJssel, 11",51.952959,4.644308,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.13,"Hollandsche IJssel, 13","Hollandsche IJssel, 13",51.936977,4.634363,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.14,"Hollandsche IJssel, 14","Hollandsche IJssel, 14",51.934631,4.620501,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.15,"Hollandsche IJssel, 15","Hollandsche IJssel, 15",51.926475,4.614403,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.16,"Hollandsche IJssel, 16","Hollandsche IJssel, 16",51.926655,4.600966,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.17,"Hollandsche IJssel, 17","Hollandsche IJssel, 17",51.921952,4.58859,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.18,"Hollandsche IJssel, 18","Hollandsche IJssel, 18",51.916286,4.579025,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.19,"Hollandsche IJssel, 19","Hollandsche IJssel, 19",51.910282,4.568625,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.19p7,"Hollandsche IJssel, 19.7","Hollandsche IJssel, 19.7",51.908232,4.559579,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.2,"Hollandsche IJssel, 2","Hollandsche IJssel, 2",52.001768,4.707096,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.7,"Hollandsche IJssel, 7","Hollandsche IJssel, 7",51.97581,4.654714,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.8,"Hollandsche IJssel, 8","Hollandsche IJssel, 8",51.971895,4.642422,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandscheijssel.9,"Hollandsche IJssel, 9","Hollandsche IJssel, 9",51.967482,4.631218,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandseijssel.km12.ntb,"Hollandse IJssel, km 12, ntb","Hollandse IJssel, km 12, ntb",51.944901,4.636616,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.noord.alpha,Hollandse Kust Noord Alpha,Hollandse Kust Noord Alpha,52.69777,4.2935,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.noord.deelgebied,"Hollandse kust, noord , deelgebied","Hollandse kust, noord , deelgebied",52.754793,4.602027,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.noord.windparknoord,"Hollandse Kust, Noord Windpark Noord","Hollandse Kust, Noord Windpark Noord",52.783,4.285,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.noord.windparkzuid,"Hollandse Kust, Noord Windpark Zuid","Hollandse Kust, Noord Windpark Zuid",52.7,4.325,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.zuid.alpha,Hollandse Kust Zuid platform Alpha,Hollandse Kust Zuid platform Alpha,52.232547,4.19569,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.zuid.windparknoord,"Hollandse Kust, Zuid Windpark Noord","Hollandse Kust, Zuid Windpark Noord",52.393,4.056,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollandsekust.zuid.windparkzuid,"Hollandse Kust, Zuid Windpark Zuid","Hollandse Kust, Zuid Windpark Zuid",52.244,4.0849,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollum.badstrand,"Hollum, badstrand","Hollum, badstrand",53.44996,5.612977,,,Netherlands,Rijkswaterstaat WaterWebservices
+hollum.strand,Hollum strand,Meetraai 49.000,53.438517,5.62002,,,Netherlands,Rijkswaterstaat WaterWebservices
+holtheme.vecht,Holtheme Vecht,vh De Haandrik,52.620833,6.698485,,,Netherlands,Rijkswaterstaat WaterWebservices
+holwerd.veersteiger,"Holwerd, Veersteiger",zie kaart HAVKT.ZIP in DONAR,53.395656,5.878059,,,Netherlands,Rijkswaterstaat WaterWebservices
+holwerderbalg,Holwerderbalg,Holwerderbalg,53.446078,5.959861,,,Netherlands,Rijkswaterstaat WaterWebservices
+hond.noord,"Hond, noord","Hond, noord",53.406346,6.921021,,,Netherlands,Rijkswaterstaat WaterWebservices
+hondweg,Hondweg,Zwolse Tocht,52.525239,5.786523,,,Netherlands,Rijkswaterstaat WaterWebservices
+honte,Honte,Honte,51.416104,3.701614,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoofdplaat,Hoofdplaat,Hoofdplaat,51.374859,3.672253,,,Netherlands,Rijkswaterstaat WaterWebservices
+hooft,Hooft,Hooft,52.339948,5.120207,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoogeplaten,Hooge Platen,Hooge Platen,51.395958,3.634094,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoogvliet,Hoogvliet,kilometer 1005.5,51.879571,4.326418,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoogzand.west,"Hoogzand, west","Hoogzand, west",53.306724,7.185298,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoorn,Hoorn,Hoorn,52.638646,5.073576,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoorn.hoornschehop.meetpaal43,"Hoorn, Hoornsche Hop, meetpaal 43","Hoorn, Hoornsche Hop, meetpaal 43",52.613174,5.062669,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoornderslag.badstrand,"Hoornderslag, badstrand","Hoornderslag, badstrand",53.016454,4.707713,,,Netherlands,Rijkswaterstaat WaterWebservices
+hoornschehop,Hoornsche Hop,Hoornsche Hop,52.613093,5.062389,,,Netherlands,Rijkswaterstaat WaterWebservices
+horn,Horn,Horn,52.29714,5.079653,,,Netherlands,Rijkswaterstaat WaterWebservices
+horsborngat,Horsborngat,Horsborngat,53.56529,6.613264,,,Netherlands,Rijkswaterstaat WaterWebservices
+horsbornzand,Horsbornzand,Horsbornzand,53.523852,6.662351,,,Netherlands,Rijkswaterstaat WaterWebservices
+horst.strandhorst,"Horst, strand Horst","Horst, strand Horst",52.3091,5.558089,,,Netherlands,Rijkswaterstaat WaterWebservices
+houtrib,Houtrib,Houtrib,52.626937,5.524557,,,Netherlands,Rijkswaterstaat WaterWebservices
+houtribdijk.ijsselmeer,"Houtribdijk, IJsselmeer","Houtribdijk, IJsselmeer",52.608956,5.486766,,,Netherlands,Rijkswaterstaat WaterWebservices
+huibertgat,Huibertgat,Huibertgat,53.57375,6.398433,,,Netherlands,Rijkswaterstaat WaterWebservices
+huibertgat.noordoost,"Huibertgat, noordoost","Huibertgat, noordoost",53.562111,6.679353,,,Netherlands,Rijkswaterstaat WaterWebservices
+huibertgat.oost,"Huibertgat, oost","Huibertgat, oost",53.559133,6.661199,,,Netherlands,Rijkswaterstaat WaterWebservices
+huisduinen,Huisduinen,Huisduinen,52.936599,4.713866,,,Netherlands,Rijkswaterstaat WaterWebservices
+huissen.nederrijn,"Huissen, Nederrijn","Huissen, Nederrijn",51.933324,5.962108,,,Netherlands,Rijkswaterstaat WaterWebservices
+huizen,Huizen,Huizen,52.316484,5.282902,,,Netherlands,Rijkswaterstaat WaterWebservices
+huizen.dedodehond,"Huizen, De Dode Hond","Huizen, De Dode Hond",52.29976,5.308186,,,Netherlands,Rijkswaterstaat WaterWebservices
+huizen.harderwijkerzand,"Huizen, Harderwijkerzand","Huizen, Harderwijkerzand",52.30211,5.279813,,,Netherlands,Rijkswaterstaat WaterWebservices
+huizen.strandzomerkade,"Huizen, strand Zomerkade","Huizen, strand Zomerkade",52.306448,5.258616,,,Netherlands,Rijkswaterstaat WaterWebservices
+hulhuizen,Hulhuizen,Hulhuizen,51.883181,6.005646,,,Netherlands,Rijkswaterstaat WaterWebservices
+hulshorst.badhoophuizen,"Hulshorst, Bad Hoophuizen","Hulshorst, Bad Hoophuizen",52.384756,5.706468,,,Netherlands,Rijkswaterstaat WaterWebservices
+hurwenen,Hurwenen,"raai 929, recreatieplas",51.814495,5.308891,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijburg.strandamsterdam,"IJburg, strand Amsterdam","IJburg, strand Amsterdam",52.348842,5.015613,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijgeul.1,"IJGeul, 1",voorheen IJmuiden stroommeetpaal,52.463943,4.517596,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden,IJmuiden,IJmuiden,52.539507,4.425641,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.20kmuitdekust,"IJmuiden, 20 km uit de kust","IJmuiden, 20 km uit de kust",52.559951,4.291509,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.3kmuitdekust,"IJmuiden, 3 km uit de kust","IJmuiden, 3 km uit de kust",52.487134,4.505329,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.binnentoeleidingskanaal,"IJmuiden, binnen toeleidingskanaal",kilometer 2,52.466014,4.622005,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven,"IJmuiden, buitenhaven","IJmuiden, buitenhaven",52.463,4.555,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.1,"IJmuiden, Buitenhaven, 1","IJmuiden, Buitenhaven, 1",52.464196,4.585028,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.2,"IJmuiden, Buitenhaven, 2","IJmuiden, Buitenhaven, 2",52.462953,4.581931,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.3,"IJmuiden, Buitenhaven, 3","IJmuiden, Buitenhaven, 3",52.469077,4.579788,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.4,"IJmuiden, Buitenhaven, 4","IJmuiden, Buitenhaven, 4",52.472108,4.59345,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.5,"IJmuiden, Buitenhaven, 5","IJmuiden, Buitenhaven, 5",52.4639,4.582355,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.6,"IJmuiden, Buitenhaven, 6","IJmuiden, Buitenhaven, 6",52.465802,4.53807,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.7,"IJmuiden, Buitenhaven, 7","IJmuiden, Buitenhaven, 7",52.460173,4.5684,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.buitenhaven.8,"IJmuiden, Buitenhaven, 8","IJmuiden, Buitenhaven, 8",52.468285,4.580848,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.havenhoofd.zuid,"IJmuiden, havenhoofd, zuid","IJmuiden, havenhoofd, zuid",52.463693,4.532283,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.kleinestrand,"IJmuiden, Kleine Strand","IJmuiden, Kleine Strand",52.461121,4.563748,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.munitiestort.1,"IJmuiden, munitiestort, 1","IJmuiden, munitiestort, 1",52.549225,4.057019,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.noordersluis.oost,"IJmuiden, noordersluis, oost","IJmuiden, noordersluis, oost",52.4672,4.614,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.noordersluis.west,"IJmuiden, noordersluis, west","IJmuiden, noordersluis, west",52.4678,4.604,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.semafoor,"IJmuiden, semafoor","IJmuiden, semafoor",52.462461,4.574391,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.semafoor.badstrand,"IJmuiden, semafoor, badstrand","IJmuiden, semafoor, badstrand",52.460331,4.570369,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijmuiden.t1,"IJmuiden, T1",Noordzeekanaal tijdelijk voor IJmuiden1,52.464155,4.626452,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km878p3.rechteroever.a,"IJssel, km 878.3, rechter oever, punt A","IJssel, km 878.3, rechter oever, punt A",51.951037,5.957152,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km878p3.rechteroever.b,"IJssel, km 878.3, rechter oever, punt B","IJssel, km 878.3, rechter oever, punt B",51.951466,5.957681,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km878p3.rechteroever.c,"IJssel, km 878.3, rechter oever, punt C","IJssel, km 878.3, rechter oever, punt C",51.951716,5.958004,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km878p8.rechteroever.a,"IJssel, km 878.8, rechter oever, punt A","IJssel, km 878.8, rechter oever, punt A",51.953387,5.952556,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km878p8.rechteroever.b,"IJssel, km 878.8, rechter oever, punt B","IJssel, km 878.8, rechter oever, punt B",51.953624,5.95381,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km878p8.rechteroever.c,"IJssel, km 878.8, rechter oever, punt C","IJssel, km 878.8, rechter oever, punt C",51.95379,5.954743,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p0.linkeroever,"IJssel, km 879.0, linker oever","IJssel, km 879.0, linker oever",51.95468,5.949291,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p0.rechteroever,"IJssel, km 879.0, rechter oever","IJssel, km 879.0, rechter oever",51.954831,5.950629,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p5.linkeroever,"IJssel, km 879.5, linker oever","IJssel, km 879.5, linker oever",51.959756,5.949027,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p5.rechteroever,"IJssel, km 879.5, rechter oever","IJssel, km 879.5, rechter oever",51.959576,5.950346,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p6.rechteroever.a,"IJssel, km 879.6, rechter oever, punt A","IJssel, km 879.6, rechter oever, punt A",51.959977,5.95226,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p6.rechteroever.b,"IJssel, km 879.6, rechter oever, punt B","IJssel, km 879.6, rechter oever, punt B",51.959791,5.953538,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km879p6.rechteroever.c,"IJssel, km 879.6, rechter oever, punt C","IJssel, km 879.6, rechter oever, punt C",51.959643,5.954468,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km880p0.linkeroever,"IJssel, km 880.0, linker oever","IJssel, km 880.0, linker oever",51.963671,5.951021,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km880p0.rechteroever,"IJssel, km 880.0, rechter oever","IJssel, km 880.0, rechter oever",51.963244,5.952234,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km880p1.rechteroever.a,"IJssel, km 880.1, rechter oever, punt A","IJssel, km 880.1, rechter oever, punt A",51.964384,5.95543,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km880p1.rechteroever.c,"IJssel, km 880.1, rechter oever, punt C","IJssel, km 880.1, rechter oever, punt C",51.963566,5.957282,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km880p2.linkeroever,"IJssel, km 880.2, linker oever","IJssel, km 880.2, linker oever",51.965465,5.952719,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km881p2.rechteroever,"IJssel, km 881.2, rechter oever","IJssel, km 881.2, rechter oever",51.970121,5.962313,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km884p1.rechteroever,"IJssel, km 884.1, rechter oever","IJssel, km 884.1, rechter oever",51.98051,6.002844,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km912p0.linkeroever,"IJssel, km 912.0, linker oever","IJssel, km 912.0, linker oever",52.051365,6.121326,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km935p1.linkeroever,"IJssel, km 935.1, linker oever","IJssel, km 935.1, linker oever",52.189923,6.157782,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km939p9.rechteroever,"IJssel, km 939.9, rechter oever","IJssel, km 939.9, rechter oever",52.217765,6.187748,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km949p9.linkeroever,"IJssel, km 949.9, linker oever","IJssel, km 949.9, linker oever",52.285151,6.110531,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km961p0.linkeroever,"IJssel, km 961.0, linker oever","IJssel, km 961.0, linker oever",52.3694,6.076813,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km970p0.linkeroever,"IJssel, km 970.0, linker oever","IJssel, km 970.0, linker oever",52.428058,6.124221,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km975p0.linkeroever,"IJssel, km 975.0, linker oever","IJssel, km 975.0, linker oever",52.467345,6.100031,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijssel.km985p0.linkeroever,"IJssel, km 985.0, linker oever","IJssel, km 985.0, linker oever",52.531407,6.013351,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijsselmeer.midden,"IJsselmeer, midden",zwaartepunt IJsselmeer,52.811246,5.372375,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijsselmeer.midden.meetpaal26,"IJsselmeer, midden, meetpaal 26","IJsselmeer, midden, meetpaal 26",52.721367,5.459433,,,Netherlands,Rijkswaterstaat WaterWebservices
+ijsselmeer.wagenpad,"IJsselmeer, Wagenpad","IJsselmeer, Wagenpad",52.804808,5.198878,,,Netherlands,Rijkswaterstaat WaterWebservices
+inschot,Inschot,Inschot,53.161988,5.185368,,,Netherlands,Rijkswaterstaat WaterWebservices
+itsoal.workum,"It Soal, Workum","It Soal, Workum",52.965695,5.411288,,,Netherlands,Rijkswaterstaat WaterWebservices
+itteren,Itteren,Itteren,50.895156,5.694315,,,Netherlands,Rijkswaterstaat WaterWebservices
+j6,J6,platform,53.816632,2.95001,,,Netherlands,Rijkswaterstaat WaterWebservices
+jaarsveld,Jaarsveld,Jaarsveld,51.969939,4.978721,,,Netherlands,Rijkswaterstaat WaterWebservices
+julianadorp,Julianadorp,Julianadorp,52.899739,4.711165,,,Netherlands,Rijkswaterstaat WaterWebservices
+junne.beneden,"Junne, beneden","Junne, beneden",52.528233,6.498508,,,Netherlands,Rijkswaterstaat WaterWebservices
+junne.boven,"Junne, boven","Junne, boven",52.527891,6.499052,,,Netherlands,Rijkswaterstaat WaterWebservices
+jutphaas,Jutphaas,Jutphaas,52.03796,5.092801,,,Netherlands,Rijkswaterstaat WaterWebservices
+k13a,K13a platform,K13a platform,53.217016,3.218922,,,Netherlands,Rijkswaterstaat WaterWebservices
+k13a.1,K13a meetboei,nabij platform,53.2155,3.2217,,,Netherlands,Rijkswaterstaat WaterWebservices
+k14,K14,platform,53.266667,3.633333,,,Netherlands,Rijkswaterstaat WaterWebservices
+kaapbrug,Kaapbrug,Kaapbrug,52.699226,6.184944,,,Netherlands,Rijkswaterstaat WaterWebservices
+kabbelaarsbank.grevelingen,"Kabbelaarsbank, Grevelingen","Kabbelaarsbank, Grevelingen",51.752415,3.862772,,,Netherlands,Rijkswaterstaat WaterWebservices
+kadoelen.zwanediep,"Kadoelen, Zwanediep","Kadoelen, Zwanediep",52.658243,5.981641,,,Netherlands,Rijkswaterstaat WaterWebservices
+kallosluis.schelde,"Kallosluis, schelde","Kallosluis, schelde",51.267822,4.29859,,,Netherlands,Rijkswaterstaat WaterWebservices
+kampen,Kampen,Kampen,52.558966,5.917924,,,Netherlands,Rijkswaterstaat WaterWebservices
+kampen.ijssel,"Kampen, IJssel",voorheen bovenhaven,52.552,5.9264,,,Netherlands,Rijkswaterstaat WaterWebservices
+kampen.keteldiep,"Kampen, Keteldiep","Kampen, Keteldiep",52.5816,5.8467,,,Netherlands,Rijkswaterstaat WaterWebservices
+kampen.scheeresluis.beneden,Kampen Scheeresluis beneden,Kampen Scheeresluis beneden,52.5308,5.94723,,,Netherlands,Rijkswaterstaat WaterWebservices
+kamperhoek.badstrand,"Kamperhoek, badstrand","Kamperhoek, badstrand",52.608088,5.641241,,,Netherlands,Rijkswaterstaat WaterWebservices
+kamperland.debanjaard.badstrand,"Kamperland, De Banjaard, badstrand","Kamperland, De Banjaard, badstrand",51.594808,3.663077,,,Netherlands,Rijkswaterstaat WaterWebservices
+kamperland.deroompot.badstrand,"Kamperland, De Roompot, badstrand","Kamperland, De Roompot, badstrand",51.593171,3.730112,,,Netherlands,Rijkswaterstaat WaterWebservices
+kamperland.schotsman,"Kamperland, Schotsman","Kamperland, Schotsman",51.581616,3.643279,,,Netherlands,Rijkswaterstaat WaterWebservices
+kamperland.schotsman.ruiterplaat,"Kamperland, Schotsman, Ruiterplaat","Kamperland, Schotsman, Ruiterplaat",51.581568,3.643262,,,Netherlands,Rijkswaterstaat WaterWebservices
+kamperland.sintfelixweg.badstrand,"Kamperland, Sint Felixweg, badstrand","Kamperland, Sint Felixweg, badstrand",51.55219,3.693537,,,Netherlands,Rijkswaterstaat WaterWebservices
+kanne,Kanne,Kanne,50.814742,5.671551,,,Netherlands,Rijkswaterstaat WaterWebservices
+karekietweg,Karekietweg,Hoge Dwarsvaart,52.407402,5.623071,,,Netherlands,Rijkswaterstaat WaterWebservices
+kats.zandkreekdam,Kats Zanskreekdam,Kats Zanskreekdam,51.541981,3.865703,,,Netherlands,Rijkswaterstaat WaterWebservices
+kats.zandkreeksluis,"Kats, Zandkreeksluis",voorheen buiten,51.543947,3.865418,,,Netherlands,Rijkswaterstaat WaterWebservices
+kats.zandkreeksluis.kolk1,Kast Zanskreeksluis kolk1,Kast Zanskreeksluis kolk1,51.543685,3.862662,,,Netherlands,Rijkswaterstaat WaterWebservices
+katsberg.inlaat,"Katsberg, inlaat",Kanaal van Deurne,51.32638,5.902401,,,Netherlands,Rijkswaterstaat WaterWebservices
+katsbinnen,Kats binnen,Kats binnen,51.543733,3.86283,,,Netherlands,Rijkswaterstaat WaterWebservices
+katseveer.badstrand,"Katseveer, badstrand","Katseveer, badstrand",51.54039,3.868421,,,Netherlands,Rijkswaterstaat WaterWebservices
+katwijk.paal,"Katwijk, paal","Katwijk, paal",52.204473,4.362436,,,Netherlands,Rijkswaterstaat WaterWebservices
+katwijkaanzee,Katwijk aan zee,Katwijk aan zee,52.211246,4.39769,,,Netherlands,Rijkswaterstaat WaterWebservices
+katwijkaanzee.boulevard.noord,"Katwijk aan Zee, Boulevard, noord","Katwijk aan Zee, Boulevard, noord",52.213953,4.398947,,,Netherlands,Rijkswaterstaat WaterWebservices
+katwijkaanzee.boulevard.zuid,"Katwijk aan Zee, Boulevard, zuid","Katwijk aan Zee, Boulevard, zuid",52.20545,4.39046,,,Netherlands,Rijkswaterstaat WaterWebservices
+katzberg,Katzberg,Katzberg,51.307036,5.848719,,,Netherlands,Rijkswaterstaat WaterWebservices
+keeten.boeikt22.slikkenvanviane,"Keeten, boei Kt22, Slikken van Viane","Keeten, boei Kt22, Slikken van Viane",51.615736,4.037881,,,Netherlands,Rijkswaterstaat WaterWebservices
+keldonk.sluis5.schuiflinks,Keldonk Sluis5 schuiflinks,Keldonk Sluis5 schuiflinks,51.5775062,5.58585052,,,Netherlands,Rijkswaterstaat WaterWebservices
+keldonk.sluis5.schuifrechts,Keldonk Sluis5 schuifrechts,Keldonk Sluis5 schuifrechts,51.57750621,5.58585052,,,Netherlands,Rijkswaterstaat WaterWebservices
+kennemerstrand,Kennemerstrand,Kennemerstrand,52.45548,4.552745,,,Netherlands,Rijkswaterstaat WaterWebservices
+kerkdriel,Kerkdriel,"raai 211, recreatieplas",51.779006,5.33721,,,Netherlands,Rijkswaterstaat WaterWebservices
+kerkdriel.campingdenbol.dagstrand,"Kerkdriel, camping den Bol, dagstrand","Kerkdriel, camping den Bol, dagstrand",51.778556,5.335036,,,Netherlands,Rijkswaterstaat WaterWebservices
+kerkdriel.dezandmeren.noord,"Kerkdriel, De Zandmeren, noord","Kerkdriel, De Zandmeren, noord",51.766013,5.347191,,,Netherlands,Rijkswaterstaat WaterWebservices
+kerkdriel.dezandmeren.westzijde,"Kerkdriel, De Zandmeren, westzijde",oude maasarm km 212,51.763281,5.348091,,,Netherlands,Rijkswaterstaat WaterWebservices
+kerkenwaard,Kerkenwaard,recreatieplas,51.822005,5.195744,,,Netherlands,Rijkswaterstaat WaterWebservices
+kerkenwaardhaaften,Kerkenwaard-Haaften,recreatieplas,51.81661,5.224047,,,Netherlands,Rijkswaterstaat WaterWebservices
+kessel,Kessel,Kessel,51.287708,6.04847,,,Netherlands,Rijkswaterstaat WaterWebservices
+ketelhaven.elandweg,"Ketelhaven, Elandweg",Swiftervaart,52.5709,5.69401,,,Netherlands,Rijkswaterstaat WaterWebservices
+ketelhaven.ketelmeer,"Ketelhaven, Ketelmeer",voorheen Ketelmond,52.5825,5.7627,,,Netherlands,Rijkswaterstaat WaterWebservices
+ketelweg,Ketelweg,Roggebottocht,52.576074,5.769281,,,Netherlands,Rijkswaterstaat WaterWebservices
+kijkduin,Kijkduin,Kijkduin,52.070859,4.218659,,,Netherlands,Rijkswaterstaat WaterWebservices
+kimstergat.oost,"Kimstergat, oost","Kimstergat, oost",53.264566,5.467386,,,Netherlands,Rijkswaterstaat WaterWebservices
+kimstergat.west,"Kimstergat, west","Kimstergat, west",53.262779,5.450149,,,Netherlands,Rijkswaterstaat WaterWebservices
+kinderdijk.lek,Kinderdijk Lek,Kinderdijk Lek,51.8883,4.62599,,,Netherlands,Rijkswaterstaat WaterWebservices
+kinderdijk.lek.km984,"Kinderdijk, Lek, km 984","Kinderdijk, Lek, km 984",51.880817,4.626168,,,Netherlands,Rijkswaterstaat WaterWebservices
+kinderdijk.lek.km988,"Kinderdijk, Lek, km 988","Kinderdijk, Lek, km 988",51.890778,4.637621,,,Netherlands,Rijkswaterstaat WaterWebservices
+kinderdijk.linkeroever.km988.8,Kinderdijk Linkeroever (kilometer 988.8),Kinderdijk Linkeroever (kilometer 988.8),51.88829964,4.625989545,,,Netherlands,Rijkswaterstaat WaterWebservices
+kloosterzande.baalhoek,"Kloosterzande, Baalhoek","Kloosterzande, Baalhoek",51.366086,4.10258,,,Netherlands,Rijkswaterstaat WaterWebservices
+klundert,Klundert,Klundert,51.689478,4.526704,,,Netherlands,Rijkswaterstaat WaterWebservices
+knock,Knock,Knock,53.327222,7.030556,,,Netherlands,Rijkswaterstaat WaterWebservices
+kopvanhetland,Kop van het Land,Kop van het Land,51.788294,4.757596,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerd,Kornwerd,Kornwerd,53.038325,5.346208,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.ijsselmeer.binnenhaven,"Kornwerderzand, IJsselmeer binnenhaven","Kornwerderzand, IJsselmeer binnenhaven",53.06835,5.337321,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.ijsselmeer.middelgronden,Kornwerderzand IJsselmeer Middelgronden,Kornwerderzand IJsselmeer Middelgronden,53.05167,5.3103,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.ijsselmeer.spui,Kornwerderzand IJsselmeer spui,Kornwerderzand IJsselmeer spui,53.06802,5.32872,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.ijsselmeer.spuihavenzuid,Kornwerderzand Spuihaven zuid,Kornwerderzand Spuihaven zuid,53.065647,5.332652,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.ijsselmeer.vaargeul,Kornwerderzand IJsselmeer vaargeul,Kornwerderzand IJsselmeer vaargeul,53.04868,5.34483,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.voorhaven,"Kornwerderzand, Voorhaven","Kornwerderzand, Voorhaven",53.071839,5.335733,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.waddenzee.buitenhaven,Kornwerderzand Waddenzee buitenhaven,Kornwerderzand Waddenzee buitenhaven,53.07459,5.334757,,,Netherlands,Rijkswaterstaat WaterWebservices
+kornwerderzand.waddenzee.voorhaven.kolk,"Kornwerderzand, Waddenzee voorhaven kolk","Kornwerderzand, Waddenzee voorhaven kolk",53.069944,5.337103,,,Netherlands,Rijkswaterstaat WaterWebservices
+kortgene,Kortgene,Kortgene,51.546479,3.80564,,,Netherlands,Rijkswaterstaat WaterWebservices
+kortgene.gebrokendak,"Kortgene, Gebroken Dak","Kortgene, Gebroken Dak",51.553349,3.83593,,,Netherlands,Rijkswaterstaat WaterWebservices
+kortgene.schapendijk.badstrand,"Kortgene, Schapendijk, badstrand","Kortgene, Schapendijk, badstrand",51.556108,3.833139,,,Netherlands,Rijkswaterstaat WaterWebservices
+kraaijenbergseplassen.2,"Kraaijenbergse Plassen, 2","Kraaijenbergse Plassen, 2",51.751339,5.832835,,,Netherlands,Rijkswaterstaat WaterWebservices
+kraaijenbergseplassen.3,"Kraaijenbergse Plassen, 3","Kraaijenbergse Plassen, 3",51.750018,5.823105,,,Netherlands,Rijkswaterstaat WaterWebservices
+krabbendijke.roelshoek.badstrand,"Krabbendijke, Roelshoek, badstrand","Krabbendijke, Roelshoek, badstrand",51.436473,4.125464,,,Netherlands,Rijkswaterstaat WaterWebservices
+krabbenkreek,Krabbenkreek,Krabbenkreek,51.610376,4.10489,,,Netherlands,Rijkswaterstaat WaterWebservices
+krabbersgat.buiten,"Krabbersgat, buiten","Krabbersgat, buiten",52.706978,5.313226,,,Netherlands,Rijkswaterstaat WaterWebservices
+krabbersgat.ijsselmeer,"Krabbersgat, IJsselmeer","voorheen, noord",52.694,5.284,,,Netherlands,Rijkswaterstaat WaterWebservices
+krabbersgat.markermeer,"Krabbersgat, Markermeer","voorheen, zuid",52.691226,5.279974,,,Netherlands,Rijkswaterstaat WaterWebservices
+kraggenburg,Kraggenburg,Kraggenburg,52.653138,5.940784,,,Netherlands,Rijkswaterstaat WaterWebservices
+kralendijk.plazabeachterminal,Kralendijk Plazabeach Terminal,Kralendijk Plazabeach Terminal,12.149638,-68.277813,,,Netherlands,Rijkswaterstaat WaterWebservices
+krammer,Krammer,Krammer,51.666276,4.095356,,,Netherlands,Rijkswaterstaat WaterWebservices
+krammerput,Krammerput,Krammerput,51.668111,4.183083,,,Netherlands,Rijkswaterstaat WaterWebservices
+krammersluislaagbekken.badstrand,"Krammersluis laagbekken, badstrand","Krammersluis laagbekken, badstrand",51.648967,4.17475,,,Netherlands,Rijkswaterstaat WaterWebservices
+krammersluizen,Krammersluizen,Krammersluizen,51.66039,4.127685,,,Netherlands,Rijkswaterstaat WaterWebservices
+krammersluizen.west,Krammersluizen west,Krammersluizen west,51.65934474,4.144263681,,,Netherlands,Rijkswaterstaat WaterWebservices
+kreekrak.noord,"Kreekrak, noord","Kreekrak, noord",51.45005,4.229827,,,Netherlands,Rijkswaterstaat WaterWebservices
+kreekrakoudediensthaven,Kreekrak oude diensthaven,Kreekrak oude diensthaven,51.446552,4.230635,,,Netherlands,Rijkswaterstaat WaterWebservices
+kreekraksluizen,Kreekraksluizen,Kreekraksluizen,51.438833,4.2409,,,Netherlands,Rijkswaterstaat WaterWebservices
+kreekraksluizen.bufferbekken.badstrand,"Kreekraksluizen, bufferbekken, badstrand","Kreekraksluizen, bufferbekken, badstrand",51.437847,4.241212,,,Netherlands,Rijkswaterstaat WaterWebservices
+krimpenaandeijssel.hollandscheijssel,"Krimpen aan de IJssel, Hollandsche IJssel","Krimpen aan de IJssel, Hollandsche IJssel",51.9165,4.579,,,Netherlands,Rijkswaterstaat WaterWebservices
+krimpenaandelek.lek,"Krimpen aan de Lek, Lek","Krimpen aan de Lek, Lek",51.890722,4.628906,,,Netherlands,Rijkswaterstaat WaterWebservices
+kuilvanmarken,Kuil van Marken,Kuil van Marken,52.478941,5.270994,,,Netherlands,Rijkswaterstaat WaterWebservices
+l9,L9,platform,53.616667,4.966667,,,Netherlands,Rijkswaterstaat WaterWebservices
+laaksestrand,Laakse strand,Laakse strand,52.257505,5.440589,,,Netherlands,Rijkswaterstaat WaterWebservices
+laar,Laar,Laar,52.6116,6.738703,,,Netherlands,Rijkswaterstaat WaterWebservices
+lageknarsluis,Lage Knarsluis,Lage Vaart,52.448161,5.43501,,,Netherlands,Rijkswaterstaat WaterWebservices
+lageweg.hollandscheijssel.groen12,Lichtopstand Rood 12 Hollandsche IJssel,Lichtopstand Rood 12 Hollandsche IJssel,51.945129,4.636945,,,Netherlands,Rijkswaterstaat WaterWebservices
+lageweg.hollandscheijssel.groen18,Lichtopstand Groen 18 Hollandsche IJssel,Lichtopstand Groen 18 Hollandsche IJssel,51.957339,4.644601,,,Netherlands,Rijkswaterstaat WaterWebservices
+lageweg.hollandscheijssel.groen26,Lichtopstand Groen 26 Hollandsche IJssel,Lichtopstand Groen 26 Hollandsche IJssel,51.971488,4.641844,,,Netherlands,Rijkswaterstaat WaterWebservices
+lageweg.hollandscheijssel.groen30,Lichtopstand Groen 30 Hollandsche IJssel,Lichtopstand Groen 30 Hollandsche IJssel,51.978059,4.664449,,,Netherlands,Rijkswaterstaat WaterWebservices
+lageweg.hollandscheijssel.groen35,Lichtopstand Rood 35 Hollandsche IJssel,Lichtopstand Rood 35 Hollandsche IJssel,51.994356,4.684584,,,Netherlands,Rijkswaterstaat WaterWebservices
+lagewitsie,Lage Witsie,Lage Witsie,51.581812,5.032859,,,Netherlands,Rijkswaterstaat WaterWebservices
+lamswaarde.boei59,"Lamswaarde, boei 59","Lamswaarde, boei 59",51.371949,4.062615,,,Netherlands,Rijkswaterstaat WaterWebservices
+lanaken,Lanaken,Lanaken,50.889528,5.683083,,,Netherlands,Rijkswaterstaat WaterWebservices
+langezand,Lange Zand,Lange Zand,53.206074,5.22183,,,Netherlands,Rijkswaterstaat WaterWebservices
+larserringweg,Larserringweg,Lage Vaart,52.505145,5.537433,,,Netherlands,Rijkswaterstaat WaterWebservices
+larserweg,Larserweg,Lage Vaart,52.499812,5.479245,,,Netherlands,Rijkswaterstaat WaterWebservices
+lauwers,Lauwers,Lauwers,53.530958,6.417102,,,Netherlands,Rijkswaterstaat WaterWebservices
+lauwers.zuid,"Lauwers, zuid","Lauwers, zuid",53.506523,6.452764,,,Netherlands,Rijkswaterstaat WaterWebservices
+lauwersoog.buitenhaven,"Lauwersoog, buitenhaven","Lauwersoog, buitenhaven",53.415004,6.206095,,,Netherlands,Rijkswaterstaat WaterWebservices
+lauwersoog.havenmond,"Lauwersoog, havenmond","Lauwersoog, havenmond",53.410553,6.199995,,,Netherlands,Rijkswaterstaat WaterWebservices
+lauwersoog.spuisluisbuiten,"Lauwersoog, spuisluis buiten","Lauwersoog, spuisluis buiten",53.410619,6.190221,,,Netherlands,Rijkswaterstaat WaterWebservices
+lauwersoog.waddenzee,"Lauwersoog, Waddenzee","Lauwersoog, Waddenzee",53.408334,6.196046,,,Netherlands,Rijkswaterstaat WaterWebservices
+lebbenbrugge,Lebbenbrugge,Slinge,52.107067,6.491016,,,Netherlands,Rijkswaterstaat WaterWebservices
+leeuwarden.vanharinxmakanaal,Leeuwarden Van Harinxmakanaal,Leeuwarden Van Harinxmakanaal,53.18341,5.79713,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km928p100.ro,"Lek, km. 928.100, ro","Lek, km. 928.100, ro",51.968377,5.347062,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km931p200.ro,"Lek, km. 931.200, ro","Lek, km. 931.200, ro",51.957646,5.312344,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km934p900.ro,"Lek, km. 934.900, ro","Lek, km. 934.900, ro",51.96938,5.26184,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km943p400.ro,"Lek, km. 943.400, ro","Lek, km. 943.400, ro",51.971415,5.16743,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km952p600.ro,"Lek, km. 952.600, ro","Lek, km. 952.600, ro",51.994253,5.064052,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km956p600.ro,"Lek, km. 956.600, ro","Lek, km. 956.600, ro",51.970142,5.026439,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km962p800.ro,"Lek, km. 962.800, ro","Lek, km. 962.800, ro",51.962591,4.957243,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km966p900.ro,"Lek, km. 966.900, ro","Lek, km. 966.900, ro",51.943967,4.914947,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km985,"Lek, km. 985","Lek, km. 985",51.89257,4.678719,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km986,"Lek, km. 986","Lek, km. 986",51.889596,4.665546,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km987,"Lek, km. 987","Lek, km. 987",51.889579,4.651282,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km988,"Lek, km. 988","Lek, km. 988",51.891114,4.636642,,,Netherlands,Rijkswaterstaat WaterWebservices
+lek.km989,"Lek, km. 989","Lek, km. 989",51.889324,4.622596,,,Netherlands,Rijkswaterstaat WaterWebservices
+lekkerkerk.lek,"Lekkerkerk, Lek","Lekkerkerk, Lek",51.89392,4.6910177,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad,Lelystad,Lelystad,52.514675,5.365108,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.haven,"Lelystad, haven","Lelystad, haven",52.505689,5.376159,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.houtribbaai,"Lelystad, Houtribbaai","Lelystad, Houtribbaai",52.541628,5.438796,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.houtribhoek,"Lelystad, Houtribhoek","Lelystad, Houtribhoek",52.560481,5.472736,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.houtribhoek.strand,"Lelystad, Houtribhoek, strand","Lelystad, Houtribhoek, strand",52.549447,5.455701,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.houtribsluis.noord,"Lelystad, Houtribsluis, noord","Lelystad, Houtribsluis, noord",52.531,5.435,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.houtribsluis.zuid,"Lelystad, Houtribsluis, zuid","Lelystad, Houtribsluis, zuid",52.526351,5.433916,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.julianapad.markermeer,"Lelystad, Julianapad, Markermeer","Lelystad, Julianapad, Markermeer",52.496702,5.372479,,,Netherlands,Rijkswaterstaat WaterWebservices
+lelystad.larservaart.meerkoetenweg,"Lelystad, Larservaart, Meerkoetenweg","Lelystad, Larservaart, Meerkoetenweg",52.475062,5.516725,,,Netherlands,Rijkswaterstaat WaterWebservices
+lemmer.ijsselmeer,"Lemmer, IJsselmeer","Lemmer, IJsselmeer",52.838,5.71,,,Netherlands,Rijkswaterstaat WaterWebservices
+lemmer.ijsselmeer.woudagemaal,Lemmer Ijsselmeer Woudagemaal,Lemmer Ijsselmeer Woudagemaal,52.8461,5.67997,,,Netherlands,Rijkswaterstaat WaterWebservices
+lemmer.stroomkanaal.teroelsterkolk,Lemmer stroomkanaal Teroelsterkolk,Lemmer stroomkanaal Teroelsterkolk,52.84515,5.6835,,,Netherlands,Rijkswaterstaat WaterWebservices
+lemmer.woudagemaal.stroomkanaal,Lemmer stroomkanaal Woudagemaal,Lemmer stroomkanaal Woudagemaal,52.84705,5.6802,,,Netherlands,Rijkswaterstaat WaterWebservices
+lemsterstrand.lemmer,"Lemsterstrand, Lemmer","Lemsterstrand, Lemmer",52.842398,5.70004,,,Netherlands,Rijkswaterstaat WaterWebservices
+lexkesveer,Lexkesveer,Lexkesveer,51.961091,5.689393,,,Netherlands,Rijkswaterstaat WaterWebservices
+lierop.sluis10.beneden,"Lierop, sluis 10, beneden","Lierop, sluis 10, beneden",51.416914,5.701031,,,Netherlands,Rijkswaterstaat WaterWebservices
+lierop.sluis10.boven,"Lierop, sluis 10, boven","Lierop, sluis 10, boven",51.415639,5.713889,,,Netherlands,Rijkswaterstaat WaterWebservices
+lierop.sluis9,Lierop ZuidWillemsvaart Sluis 9,Lierop ZuidWillemsvaart Sluis 9,51.447855,5.685737,,,Netherlands,Rijkswaterstaat WaterWebservices
+lierop.sluis9.boven,Lierop ZuidWillemsvaart Sluis 9 boven,Lierop ZuidWillemsvaart Sluis 9 boven,51.447698,5.684527,,,Netherlands,Rijkswaterstaat WaterWebservices
+lieshout.donkersvoortseloop,"Lieshout, Donkersvoortseloop",AA19,51.511872,5.562284,,,Netherlands,Rijkswaterstaat WaterWebservices
+lieshout.donkervoortseloop,"Lieshout, Donkervoortseloop","Lieshout, Donkervoortseloop",51.511869,5.562289,,,Netherlands,Rijkswaterstaat WaterWebservices
+linne.boven,"Linne, boven","Linne, boven",51.167731,5.921065,,,Netherlands,Rijkswaterstaat WaterWebservices
+linne.stuw.beneden,"Linne, stuw, beneden","Linne, stuw, beneden",51.167907,5.921925,,,Netherlands,Rijkswaterstaat WaterWebservices
+linne.stuw.boven,"Linne, stuw, boven","Linne, stuw, boven",51.168812,5.922507,,,Netherlands,Rijkswaterstaat WaterWebservices
+lith,Lith,Lith,51.808928,5.456078,,,Netherlands,Rijkswaterstaat WaterWebservices
+lith.beneden,"Lith, beneden dorp",voorheen dorp,51.8105,5.433,,,Netherlands,Rijkswaterstaat WaterWebservices
+lith.boven,"Lith, boven","Lith, boven",51.81,5.455,,,Netherlands,Rijkswaterstaat WaterWebservices
+lith.sluis,"Lith, beneden sluis","Lith, beneden sluis",51.80911,5.452453,,,Netherlands,Rijkswaterstaat WaterWebservices
+lithseham.dagstrand,"Lithse Ham, dagstrand","Lithse Ham, dagstrand",51.810923,5.412579,,,Netherlands,Rijkswaterstaat WaterWebservices
+lithseham.gemeentestrand,"Lithse Ham, gemeentestrand","Lithse Ham, gemeentestrand",51.815416,5.417657,,,Netherlands,Rijkswaterstaat WaterWebservices
+lithseham.recreatieplas,"Lithse Ham, recreatieplas","Lithse Ham, recreatieplas",51.817214,5.414758,,,Netherlands,Rijkswaterstaat WaterWebservices
+lixhebiefaval,Lixhe Bief Aval,Lixhe Bief Aval,50.759639,5.680889,,,Netherlands,Rijkswaterstaat WaterWebservices
+lobith.bovenrijn.haven,"Lobith, Bovenrijn, haven","Lobith, Bovenrijn, haven",51.857505,6.083651,,,Netherlands,Rijkswaterstaat WaterWebservices
+lobith.bovenrijn.tolkamer,"Lobith, Bovenrijn, Tolkamer","Lobith, Bovenrijn, Tolkamer",51.8495,6.1024,,,Netherlands,Rijkswaterstaat WaterWebservices
+lobith.ponton,"Lobith, ponton","Lobith, ponton",51.854205,6.091178,,,Netherlands,Rijkswaterstaat WaterWebservices
+lodijkschegat.speelmansplaten,"Lodijksche Gat, Speelmansplaten","Lodijksche Gat, Speelmansplaten",51.497363,4.145091,,,Netherlands,Rijkswaterstaat WaterWebservices
+lodijksegat,Lodijkse Gat,Lodijkse Gat,51.515274,4.127053,,,Netherlands,Rijkswaterstaat WaterWebservices
+loenderveenseplas,Loenderveense Plas,Loenderveense Plas,52.201302,5.037454,,,Netherlands,Rijkswaterstaat WaterWebservices
+loenen,Loenen,Loenen,52.225746,5.007405,,,Netherlands,Rijkswaterstaat WaterWebservices
+loowaard.recreatieplas,"Loowaard, recreatieplas","Loowaard, recreatieplas",51.919049,5.987533,,,Netherlands,Rijkswaterstaat WaterWebservices
+lopikerkapel.recreatieplas,"Lopikerkapel, recreatieplas","Lopikerkapel, recreatieplas",51.987433,5.053972,,,Netherlands,Rijkswaterstaat WaterWebservices
+lutjewad,Lutjewad,Lutjewad,53.432074,6.311981,,,Netherlands,Rijkswaterstaat WaterWebservices
+maarssen.kanaal,"Maarssen, kanaal","Maarssen, kanaal",52.133807,5.039151,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasband,Maasband,Maasband,50.975804,5.735743,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasbracht,Maasbracht,Maasbracht,51.140975,5.873028,,,Netherlands,Rijkswaterstaat WaterWebservices
+maaseik,Maaseik,Maaseik,51.093263,5.798297,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasgouw.dilkensplas.1,"Maasgouw, Dilkensplas, meetpunt 1","Maasgouw, Dilkensplas, meetpunt 1",51.110991,5.817734,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasgouw.dilkensplas.2,"Maasgouw, Dilkensplas, meetpunt 2","Maasgouw, Dilkensplas, meetpunt 2",51.110399,5.814915,,,Netherlands,Rijkswaterstaat WaterWebservices
+maashees,Maashees,Maashees,51.570287,6.036452,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasmond,Maasmond,Maasmond,51.989327,4.044855,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasmond.stroommeetpaal,"Maasmond, stroommeetpaal","Maasmond, stroommeetpaal",51.992205,4.007711,,,Netherlands,Rijkswaterstaat WaterWebservices
+maassluis,Maassluis,Maassluis,51.917507,4.249788,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht,Maastricht,Maastricht,50.856549,5.694513,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.borgharen.julianakanaal,"Maastricht, Borgharen, Julianakanaal","Maastricht, Borgharen, Julianakanaal",50.869,5.6995,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.borgharen.maas.beneden,"Maastricht, Borgharen, Maas, beneden",Borgharen Dorp,50.8724,5.691,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.borgharen.maas.boven,"Maastricht, Borgharen, Maas, boven",stuw,50.868809,5.698089,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.bosscherveld,Maastricht Bosscherveld overlaat,Maastricht Bosscherveld overlaat,50.869849,5.687038,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.grindgat.oostmaarland.1,"Maastricht, Grindgat, Oost-Maarland, 1","camping, oosterdriessen",50.800522,5.704213,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.grindgat.oostmaarland.2,"Maastricht, Grindgat, Oost-Maarland, 2","Maastricht, Grindgat, Oost-Maarland, 2",50.803416,5.704544,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.servaasbrug,"Maastricht, Servaasbrug","Maastricht, Servaasbrug",50.849626,5.695035,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.sintpieter,"Maastricht, Sint Pieter",voorheen noord,50.830294,5.69732,,,Netherlands,Rijkswaterstaat WaterWebservices
+maastricht.sintpieter.zuid,Maastricht Sint Pieter zuid,Maastricht Sint Pieter zuid,50.8279,5.6977,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasvlakte.2kmuitdekust,"Maasvlakte, 2 km uit de kust","Maasvlakte, 2 km uit de kust",51.924953,3.964834,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasvlakte.amaliahaven,Maasvlakte Amaliahaven,Maasvlakte Amaliahaven,51.96219,3.99496,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasvlakte.badstrand,"Maasvlakte, badstrand","Maasvlakte, badstrand",51.953064,4.018298,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasvlakte.europahaven,Maasvlakte Europahaven,Maasvlakte Europahaven,51.962167,4.029139,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasvlakte.hartelhaven,"Maasvlakte, Hartelhaven","Maasvlakte, Hartelhaven",51.929692,4.042464,,,Netherlands,Rijkswaterstaat WaterWebservices
+maasvlakte.ruim1kmuitdekust,"Maasvlakte, ruim1 km uit de kust",Ma-III,51.938567,3.996327,,,Netherlands,Rijkswaterstaat WaterWebservices
+maeslantkering.binnen,"Maeslantkering, binnen","Maeslantkering, binnen",51.951517,4.169381,,,Netherlands,Rijkswaterstaat WaterWebservices
+maeslantkering.buiten,"Maeslantkering, buiten","Maeslantkering, buiten",51.958461,4.156489,,,Netherlands,Rijkswaterstaat WaterWebservices
+makkum.sluis.buiten,Makkum sluis buiten,Makkum sluis buiten,53.05451,5.40223,,,Netherlands,Rijkswaterstaat WaterWebservices
+malden.maaswaalkanaal.inlaatteersesluispolder,Malden Maaswaalkanaal Inlaat Teersesluispolder,Malden Maaswaalkanaal Inlaat Teersesluispolder,51.78926,5.83495,,,Netherlands,Rijkswaterstaat WaterWebservices
+malzwin,Malzwin,Malzwin,52.993133,4.900946,,,Netherlands,Rijkswaterstaat WaterWebservices
+malzwin.boei1,"Malzwin, boei 1","Malzwin, boei 1",52.994689,4.955291,,,Netherlands,Rijkswaterstaat WaterWebservices
+malzwin.marinehaven,"Malzwin, marinehaven","Malzwin, marinehaven",52.968368,4.79033,,,Netherlands,Rijkswaterstaat WaterWebservices
+maren,Maren,"raai 210, recreatieplas",51.792491,5.342268,,,Netherlands,Rijkswaterstaat WaterWebservices
+marienberg.beneden,"Marienberg, beneden","Marienberg, beneden",52.519819,6.566996,,,Netherlands,Rijkswaterstaat WaterWebservices
+marienberg.boven,"Marienberg, boven","Marienberg, boven",52.520265,6.567376,,,Netherlands,Rijkswaterstaat WaterWebservices
+markelo,Markelo,voorheen Markelose brug,52.198063,6.511601,,,Netherlands,Rijkswaterstaat WaterWebservices
+marken.strand,"Marken, strand","Marken, strand",52.457275,5.098652,,,Netherlands,Rijkswaterstaat WaterWebservices
+marken.vuurtoren,"Marken, vuurtoren","Marken, vuurtoren",52.459596,5.139289,,,Netherlands,Rijkswaterstaat WaterWebservices
+markengouwzee,Marken Gouwzee,Marken Gouwzee,52.46037,5.085581,,,Netherlands,Rijkswaterstaat WaterWebservices
+markermeer.midden,"Markermeer, midden","Markermeer, midden",52.5317,5.23124,,,Netherlands,Rijkswaterstaat WaterWebservices
+markermeer.midden.meetpaal42,"Markermeer, midden, meetpaal 42","Markermeer, midden, meetpaal 42",52.532172,5.23158,,,Netherlands,Rijkswaterstaat WaterWebservices
+markermeer.noordoost,"Markermeer, noordoost","Markermeer, noordoost",52.563653,5.35476,,,Netherlands,Rijkswaterstaat WaterWebservices
+markermeer.trintelzand,Markermeer Trintelzand,Markermeer Trintelzand,52.62412,5.37297,,,Netherlands,Rijkswaterstaat WaterWebservices
+markerwaarddijk.ijsselmeer.zuidwest.meetpaal37,"Markerwaarddijk, IJsselmeer, zuidwest, meetpaal 37","Markerwaarddijk, IJsselmeer, zuidwest, meetpaal 37",52.667458,5.387205,,,Netherlands,Rijkswaterstaat WaterWebservices
+markerwadden.meetpaal,"Marker Wadden, meetpaal","Marker Wadden, meetpaal",52.600306,5.391222,,,Netherlands,Rijkswaterstaat WaterWebservices
+markerwadden.oost.meetpaal44,"Markerwadden, oost, meetpaal 44","Markerwadden, oost, meetpaal 44",52.577701,5.41817,,,Netherlands,Rijkswaterstaat WaterWebservices
+marollegat,Marollegat,Marollegat,51.479747,4.191958,,,Netherlands,Rijkswaterstaat WaterWebservices
+marsdiep.noord,"Marsdiep, noord","Marsdiep, noord",52.982538,4.749934,,,Netherlands,Rijkswaterstaat WaterWebservices
+maurik.mauriksewetering,Maurik Mauriksewetering,Maurik Mauriksewetering,51.94173,5.38961,,,Netherlands,Rijkswaterstaat WaterWebservices
+medemblik.vooroever.hetnesbos,"Medemblik, Vooroever, Het Nesbos","Medemblik, Vooroever, Het Nesbos",52.755223,5.124689,,,Netherlands,Rijkswaterstaat WaterWebservices
+medemblik.vooroever.vlietsingelpoel,"Medemblik, Vooroever, Vlietsingel Poel","Medemblik, Vooroever, Vlietsingel Poel",52.764619,5.119063,,,Netherlands,Rijkswaterstaat WaterWebservices
+megen,Megen,Megen,51.828495,5.566793,,,Netherlands,Rijkswaterstaat WaterWebservices
+megen.maas,"Megen, Maas",dorp,51.827827,5.563091,,,Netherlands,Rijkswaterstaat WaterWebservices
+meijel.kanaal.beneden,Meijel Stuw Katsberg beneden,Meijel Stuw Katsberg beneden,51.326559,5.902689,,,Netherlands,Rijkswaterstaat WaterWebservices
+meijel.kanaal.boven,Meijel Stuw Katsberg boven,Meijel Stuw Katsberg boven,51.3262,5.9024,,,Netherlands,Rijkswaterstaat WaterWebservices
+meppel.hoofdvaart,"Meppel, hoofdvaart",Galgenkampsbrug,52.702059,6.185111,,,Netherlands,Rijkswaterstaat WaterWebservices
+middelaar.dekop.maas.km159p25.pq2,"Middelaar, De Kop, Maas, km 159.25, PQ 02","Middelaar, De Kop, Maas, km 159.25, PQ 02",51.718179,5.919352,,,Netherlands,Rijkswaterstaat WaterWebservices
+middelharnis,Middelharnis,Middelharnis,51.773561,4.192414,,,Netherlands,Rijkswaterstaat WaterWebservices
+middelharnis.badstrand,"Middelharnis, badstrand","Middelharnis, badstrand",51.771983,4.193731,,,Netherlands,Rijkswaterstaat WaterWebservices
+middelharnis.meetboei,"Middelharnis, meetboei","Middelharnis, meetboei",51.776524,4.192119,,,Netherlands,Rijkswaterstaat WaterWebservices
+middelwaard,Middelwaard,Middelwaard,51.994143,5.075122,,,Netherlands,Rijkswaterstaat WaterWebservices
+midderburg.draaibrug,"Midderburg, draaibrug","Midderburg, draaibrug",51.495488,3.616576,,,Netherlands,Rijkswaterstaat WaterWebservices
+mierlo.goorloop.gemaal,"Mierlo, Goorloop, gemaal","Mierlo, Goorloop, gemaal",51.456467,5.656469,,,Netherlands,Rijkswaterstaat WaterWebservices
+mierlo.goorloop.inlaat1,Mierlo Goorloop inlaat1,Mierlo Goorloop inlaat1,51.45647,5.65654,,,Netherlands,Rijkswaterstaat WaterWebservices
+millingenaanderijn,Millingen a/d Rijn,Millingen a/d Rijn,51.872957,6.034838,,,Netherlands,Rijkswaterstaat WaterWebservices
+mirnserklif.mirns,"Mirnser Klif, Mirns","Mirnser Klif, Mirns",52.850437,5.480474,,,Netherlands,Rijkswaterstaat WaterWebservices
+mississippihaven,Mississippihaven,Mississippihaven,51.934244,4.045135,,,Netherlands,Rijkswaterstaat WaterWebservices
+moerdijk,Moerdijk,Moerdijk,51.712,4.615,,,Netherlands,Rijkswaterstaat WaterWebservices
+moerdijk.brug,"Moerdijk, brug",station troebelheidmeting,51.716367,4.636542,,,Netherlands,Rijkswaterstaat WaterWebservices
+moerdijk.bruggen,"Moerdijk, bruggen","Moerdijk, bruggen",51.716769,4.639495,,,Netherlands,Rijkswaterstaat WaterWebservices
+molengat,Molengat,Molengat,53.427194,5.726886,,,Netherlands,Rijkswaterstaat WaterWebservices
+molenplaat.midden,"Molenplaat, midden","Molenplaat, midden",51.497866,4.219969,,,Netherlands,Rijkswaterstaat WaterWebservices
+molkwerum.molkwerum,"Molkwerum, Molkwerum","Molkwerum, Molkwerum",52.905866,5.396689,,,Netherlands,Rijkswaterstaat WaterWebservices
+mondderdonge,Mond der Donge,Mond der Donge,51.709911,4.847381,,,Netherlands,Rijkswaterstaat WaterWebservices
+mondderdonge.brug,"Mond der Donge, brug","Mond der Donge, brug",51.711313,4.859084,,,Netherlands,Rijkswaterstaat WaterWebservices
+mondvandedollard,Mond van de Dollard,Mond van de Dollard,53.311917,7.081537,,,Netherlands,Rijkswaterstaat WaterWebservices
+mondvandedollard.noord,"Mond van de Dollard, noord","Mond van de Dollard, noord",53.316846,7.082481,,,Netherlands,Rijkswaterstaat WaterWebservices
+mook,Mook,Mook,51.758,5.8645,,,Netherlands,Rijkswaterstaat WaterWebservices
+mook.haven,"Mook, haven","Mook, haven",51.750295,5.880296,,,Netherlands,Rijkswaterstaat WaterWebservices
+muiden,Muiden,Muiden,52.330006,5.068863,,,Netherlands,Rijkswaterstaat WaterWebservices
+muiden.haven,"Muiden, haven","Muiden, haven",52.332168,5.070461,,,Netherlands,Rijkswaterstaat WaterWebservices
+muiderberg,Muiderberg,Muiderberg,52.329204,5.12281,,,Netherlands,Rijkswaterstaat WaterWebservices
+muizenhol,Muizenhol,Muizenhol,51.49859,5.677731,,,Netherlands,Rijkswaterstaat WaterWebservices
+munnikplaat,Munnikplaat,Munnikplaat,52.908925,5.228753,,,Netherlands,Rijkswaterstaat WaterWebservices
+naarden,Naarden,Naarden,52.310959,5.161865,,,Netherlands,Rijkswaterstaat WaterWebservices
+naarderbos,Naarderbos,Naarderbos,52.317819,5.144671,,,Netherlands,Rijkswaterstaat WaterWebservices
+natewisch,Natewisch,recreatieplas,51.973164,5.387203,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km879p000linkeroever,"Nederrijn, km. 879.000 Linker oever","Nederrijn, km. 879.000 Linker oever",51.952653,5.94474,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km879p000rechteroever,"Nederrijn, km. 879.000 Rechter oever","Nederrijn, km. 879.000 Rechter oever",51.953903,5.946518,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km879p500linkeroever,"Nederrijn, km. 879.500 Linker oever","Nederrijn, km. 879.500 Linker oever",51.955092,5.940171,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km879p500rechteroever,"Nederrijn, km. 879.500 Rechter oever","Nederrijn, km. 879.500 Rechter oever",51.956141,5.942073,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km880p000linkeroever,"Nederrijn, km. 880.000 Linker oever","Nederrijn, km. 880.000 Linker oever",51.95901,5.93515,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km880p000rechteroever,"Nederrijn, km. 880.000 Rechter oever","Nederrijn, km. 880.000 Rechter oever",51.960094,5.937439,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km880p100rechteroever,"Nederrijn, km. 880.100 Rechter oever","Nederrijn, km. 880.100 Rechter oever",51.959211,5.937629,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km882p700linkeroever,"Nederrijn, km. 882.700 Linker oever","Nederrijn, km. 882.700 Linker oever",51.973219,5.912632,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km887p000linkeroever,"Nederrijn, km. 887.000 Linker oever","Nederrijn, km. 887.000 Linker oever",51.969934,5.864993,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km896p100linkeroever,"Nederrijn, km. 896.100 Linker oever","Nederrijn, km. 896.100 Linker oever",51.969556,5.743784,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km900p300linkeroever,"Nederrijn, km. 900.300 Linker oever","Nederrijn, km. 900.300 Linker oever",51.959139,5.687422,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km904p200rechteroever,"Nederrijn, km. 904.200 Rechter oever","Nederrijn, km. 904.200 Rechter oever",51.948496,5.636846,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km913p400rechteroever,"Nederrijn, km. 913.400 Rechter oever","Nederrijn, km. 913.400 Rechter oever",51.971544,5.525016,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederrijn.km918p200rechteroever,"Nederrijn, km. 918.200 Rechter oever","Nederrijn, km. 918.200 Rechter oever",51.984116,5.460065,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert,Nederweert,Nederweert,51.272393,5.74975,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.bovenstroomsluis,"Nederweert, bovenstroomsluis","Nederweert, bovenstroomsluis",51.327502,5.747318,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.boven,"Nederweert, sluis 15, boven","Nederweert, sluis 15, boven",51.2728,5.7497,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.bypass,"Nederweert, Sluis 15, bypass","Nederweert, Sluis 15, bypass",51.272606,5.751183,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.inlaat,"Nederweert, Sluis 15, inlaat",Spuien,51.272625,5.751183,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.uitlaat,"Nederweert, Sluis 15, uitlaat",NettobalansUIT,51.272614,5.751183,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.voedingskanaal,"Nederweert, sluis 15, voedingskanaal","Nederweert, sluis 15, voedingskanaal",51.27268,5.7516,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.voedingskanaal1,"Nederweert, Sluis 15, voedingskanaal 1","Nederweert, Sluis 15, voedingskanaal 1",51.272611,5.751183,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweert.sluis15.voedingskanaal2,"Nederweert, Sluis 15, voedingskanaal 2","Nederweert, Sluis 15, voedingskanaal 2",51.272608,5.751183,,,Netherlands,Rijkswaterstaat WaterWebservices
+nederweerteind.noordervaart,Nederweert-Eind,Nederweert-Eind,51.28051,5.77045,,,Netherlands,Rijkswaterstaat WaterWebservices
+neeltjejans.badstrand,"Neeltje Jans, badstrand","Neeltje Jans, badstrand",51.642656,3.707639,,,Netherlands,Rijkswaterstaat WaterWebservices
+neeltjejans.buitenhaven,"Neeltje Jans, Buitenhaven","Neeltje Jans, Buitenhaven",51.639708,3.702692,,,Netherlands,Rijkswaterstaat WaterWebservices
+neer,Neer,Neer,51.2604,6.0055,,,Netherlands,Rijkswaterstaat WaterWebservices
+negenoord.oost,"Negenoord, oost","Negenoord, oost",51.030139,5.759722,,,Netherlands,Rijkswaterstaat WaterWebservices
+negenoord.west,"Negenoord, west","Negenoord, west",51.029639,5.759194,,,Netherlands,Rijkswaterstaat WaterWebservices
+neunen.beeksewaterloop,"Neunen, Beekse Waterloop","Neunen, Beekse Waterloop",51.513769,5.551481,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwegein.doorslag,"Nieuwegein, Doorslag","Nieuwegein, Doorslag",52.0323,5.089851,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwegein.lekkanaal,"Nieuwegein, lekkanaal","Nieuwegein, lekkanaal",52.022729,5.113007,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwemaas.990,"Nieuwe Maas, 990","Nieuwe Maas, 990",51.891361,4.608411,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwemaas.991,"Nieuwe Maas, 991","Nieuwe Maas, 991",51.894192,4.594793,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwemaas.992,"Nieuwe Maas, 992","Nieuwe Maas, 992",51.900321,4.584136,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwemaas.993,"Nieuwe Maas, 993","Nieuwe Maas, 993",51.903592,4.570854,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwemaas.994,"Nieuwe Maas, 994","Nieuwe Maas, 994",51.905101,4.556614,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwemaas.995,"Nieuwe Maas, 995","Nieuwe Maas, 995",51.903912,4.544909,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwendam,Nieuwendam,Nieuwendam,52.37484,4.951428,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwersluis,Nieuwersluis,Nieuwersluis,52.202172,4.999561,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwestatenzijl.buiten,"Nieuwe Statenzijl, buiten","Nieuwe Statenzijl, buiten",53.254251,7.175424,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwestatenzijl.dollard,"Nieuwe Statenzijl, Dollard","Nieuwe Statenzijl, Dollard",53.231562,7.207423,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwewaterweg.meetboeinw2,"Nieuwe Waterweg, meetboei NW2",km 1014.700,51.89844,4.296041,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwhaamstede.badstrand,"Nieuw Haamstede, badstrand","Nieuw Haamstede, badstrand",51.705864,3.677076,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwhaamstede.vuurtorenpad.badstrand,"Nieuw Haamstede, Vuurtorenpad, badstrand","Nieuw Haamstede, Vuurtorenpad, badstrand",51.714319,3.683558,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwhulckesteyn,Nieuw-Hulckesteyn,badstrand,52.255704,5.463053,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwpoort.lek,Nieuwpoort Lek,Nieuwpoort Lek,51.939076,4.8638976,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwvlietbad.oost.badstrand,"Nieuwvliet-Bad, oost, badstrand","Nieuwvliet-Bad, oost, badstrand",51.393569,3.454546,,,Netherlands,Rijkswaterstaat WaterWebservices
+nieuwvossemeer,Nieuw-Vossemeer,Nieuw-Vossemeer,51.584608,4.201577,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijkerk.2,"Nijkerk, 02","Nijkerk, 02",52.255659,5.44788,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijkerk.nijkerkernauw,"Nijkerk, Nijkerkernauw","Nijkerk, Nijkerkernauw",52.261739,5.470182,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijkerk.nijkerkersluis,"Nijkerk, Nijkerkersluis","Nijkerk, Nijkerkersluis",52.262993,5.476557,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijkerk.nuldernauw,"Nijkerk, Nuldernauw","Nijkerk, Nuldernauw",52.262814,5.475311,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijmegen,Nijmegen,Nijmegen,51.850241,5.85991,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijmegen.maaswaalkanaal.inlaatlandsweijer,Nijmegen Maaswaalkanaal Inlaat Landsweijer,Nijmegen Maaswaalkanaal Inlaat Landsweijer,51.82919,5.80625,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijmegen.maaswaalkanaal.inlaatweurt,Nijmegen Maaswaalkanaal Inlaat Weurt,Nijmegen Maaswaalkanaal Inlaat Weurt,51.84111,5.81146,,,Netherlands,Rijkswaterstaat WaterWebservices
+nijmegen.waal,"Nijmegen, Waal",voorheen Nijmegen haven,51.853,5.854,,,Netherlands,Rijkswaterstaat WaterWebservices
+nonnetjesweg,Nonnetjesweg,Hoge Vaart,52.416478,5.623854,,,Netherlands,Rijkswaterstaat WaterWebservices
+noord.981,"Noord, 981","Noord, 981",51.859825,4.650897,,,Netherlands,Rijkswaterstaat WaterWebservices
+noord.982,"Noord, 982","Noord, 982",51.866749,4.641462,,,Netherlands,Rijkswaterstaat WaterWebservices
+noord.983,"Noord, 983","Noord, 983",51.873297,4.632278,,,Netherlands,Rijkswaterstaat WaterWebservices
+noord.984,"Noord, 984","Noord, 984",51.881185,4.626074,,,Netherlands,Rijkswaterstaat WaterWebservices
+noorderbalgen,Noorderbalgen,Noorderbalgen,53.358039,5.380449,,,Netherlands,Rijkswaterstaat WaterWebservices
+noorderdam,Noorderdam,Noorderdam,51.980839,4.089509,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordergat.vandeplomp.badstrand,"Noordergat, van de Plomp, badstrand","Noordergat, van de Plomp, badstrand",51.719079,4.7917,,,Netherlands,Rijkswaterstaat WaterWebservices
+noorderplas.doorlaatbrug.beneden,"Noorderplas, doorlaat brug, beneden","Noorderplas, doorlaat brug, beneden",51.201672,5.964438,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordmeep.oost,"Noord Meep, oost","Noord Meep, oost",53.336464,5.333917,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordpolderzijl,Noordpolderzijl,Noordpolderzijl,53.432884,6.582293,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwaard,Noordwaard,Noordwaard,51.794683,4.849518,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.10kmuitdekust.flachsee,"Noordwijk, 10 km uit de kust Flachsee",Flachseemeting,52.290014,4.305106,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.1kmuitdekust,"Noordwijk, 1 km uit de kust","Noordwijk, 1 km uit de kust",52.255608,4.418981,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.20kmuitdekust,"Noordwijk, 20 km uit de kust","Noordwijk, 20 km uit de kust",52.340886,4.173695,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.2kmuitdekust.flachsee,"Noordwijk, 2 km uit de kust Flachsee",Flachseemeting,52.253814,4.412317,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.30kmuitdekust,"Noordwijk, 30 km uit de kust","Noordwijk, 30 km uit de kust",52.386719,4.046746,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.4kmuitdekust.flachsee,"Noordwijk, 4 km uit de kust Flachsee",Flachseemeting,52.268569,4.368681,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.50kmuitdekust,"Noordwijk, 50 km uit de kust","Noordwijk, 50 km uit de kust",52.480053,3.785347,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.5kmuitdekust,"Noordwijk, 5 km uit de kust","Noordwijk, 5 km uit de kust",52.27423,4.352034,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.70kmuitdekust,"Noordwijk, 70 km uit de kust","Noordwijk, 70 km uit de kust",52.585331,3.53006,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.aanzee,"Noordwijk, aan Zee","Noordwijk, aan Zee",52.27761,4.454418,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijk.meetpost,"Noordwijk, meetpost","Noordwijk, meetpost",52.273107,4.294811,,,Netherlands,Rijkswaterstaat WaterWebservices
+noordwijkaanzee.boulevard,"Noordwijk aan Zee, Boulevard","Noordwijk aan Zee, Boulevard",52.243415,4.424869,,,Netherlands,Rijkswaterstaat WaterWebservices
+nulderhoek,Nulderhoek,Nulderhoek,52.267329,5.502319,,,Netherlands,Rijkswaterstaat WaterWebservices
+numansdorp,Numansdorp,Numansdorp,51.716285,4.436327,,,Netherlands,Rijkswaterstaat WaterWebservices
+nunnenplaatje.zuidwest,"Nunnenplaatje, zuidwest","Nunnenplaatje, zuidwest",51.643984,3.86726,,,Netherlands,Rijkswaterstaat WaterWebservices
+obbicht,Obbicht,Obbicht,51.023587,5.775726,,,Netherlands,Rijkswaterstaat WaterWebservices
+ochten,Ochten,Ochten,51.903374,5.563024,,,Netherlands,Rijkswaterstaat WaterWebservices
+oensel.hurwenensekil,"Oensel, Hurwenensekil","kilometer 932, recreatieplas",51.811784,5.290045,,,Netherlands,Rijkswaterstaat WaterWebservices
+oesterdam,Oesterdam,Oesterdam,51.473934,4.227061,,,Netherlands,Rijkswaterstaat WaterWebservices
+oesterdam.speelmansplaten.badstrand,"Oesterdam, Speelmansplaten, badstrand","Oesterdam, Speelmansplaten, badstrand",51.501648,4.18516,,,Netherlands,Rijkswaterstaat WaterWebservices
+oesterdam.westzijde.badstrand,"Oesterdam, westzijde, badstrand","Oesterdam, westzijde, badstrand",51.478623,4.219455,,,Netherlands,Rijkswaterstaat WaterWebservices
+oheenlaak.oudemaas.brug.beneden,"Ohe en Laak, Oude Maas, brug, beneden","Ohe en Laak, Oude Maas, brug, beneden",51.111202,5.850496,,,Netherlands,Rijkswaterstaat WaterWebservices
+oheenlaak.oudemaas.brug.boven,"Ohe en Laak, Oude Maas, brug, boven","Ohe en Laak, Oude Maas, brug, boven",51.11028,5.849945,,,Netherlands,Rijkswaterstaat WaterWebservices
+oijen,Oijen,Oijen,51.823626,5.509044,,,Netherlands,Rijkswaterstaat WaterWebservices
+olburgen.zwarteschaar,"Olburgen, Zwarte Schaar","Olburgen, Zwarte Schaar",52.03555,6.136088,,,Netherlands,Rijkswaterstaat WaterWebservices
+oldebroekerweg,Oldebroekerweg,Oldebroekertocht,52.461181,5.721204,,,Netherlands,Rijkswaterstaat WaterWebservices
+oliegeul,Oliegeul,Oliegeul,51.65101,3.738763,,,Netherlands,Rijkswaterstaat WaterWebservices
+olst,Olst,Olst,52.34201,6.10448,,,Netherlands,Rijkswaterstaat WaterWebservices
+olsterweg,Olsterweg,Oostwoldertocht,52.486208,5.767031,,,Netherlands,Rijkswaterstaat WaterWebservices
+omdraai,Omdraai,Omdraai,53.103713,5.189491,,,Netherlands,Rijkswaterstaat WaterWebservices
+ommen.ommerkanaal,"Ommen, Ommerkanaal",km 0.8,52.523367,6.402053,,,Netherlands,Rijkswaterstaat WaterWebservices
+ommen.vecht,"Ommen, Vecht",voorheen  Hesselmulertbrug,52.517096,6.421919,,,Netherlands,Rijkswaterstaat WaterWebservices
+ool,Ool,km 76.5,51.190237,5.951867,,,Netherlands,Rijkswaterstaat WaterWebservices
+oolerplas,Oolerplas,Oolerplas,51.187211,5.945608,,,Netherlands,Rijkswaterstaat WaterWebservices
+ooltgensplaat.hellegat.badstrand,"Ooltgensplaat, Hellegat, badstrand","Ooltgensplaat, Hellegat, badstrand",51.684634,4.425265,,,Netherlands,Rijkswaterstaat WaterWebservices
+oort,Oort,zuidrand Brakzand,53.424277,6.242051,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterdijk,Oosterdijk,Oosterdijk,52.750662,5.267284,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhoofd,Oosterhoofd,Oosterhoofd,53.316607,7.014638,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout,Oosterhout,Oosterhout,51.630371,4.871365,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.markduiker,"Oosterhout, Markduiker","Oosterhout, Markduiker",51.645856,4.834048,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.marksluis.beneden,"Oosterhout, Marksluis, beneden","Oosterhout, Marksluis, beneden",51.647889,4.830861,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.marksluis.boven,"Oosterhout, Marksluis, boven","Oosterhout, Marksluis, boven",51.648139,4.833494,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.marksluis.inlaat,"Oosterhout, Marksluis, inlaat",NettobalansIN,51.648139,4.833494,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.marksluis.uitlaat,"Oosterhout, Marksluis, uitlaat",Schutten,51.648142,4.833494,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.boven,"Oosterhout, sluis 1, boven","Oosterhout, sluis 1, boven",51.643,5.83975,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.gemaal,"Oosterhout, Sluis 1, gemaal",Malen,51.643014,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.inlaat,"Oosterhout, Sluis 1, inlaat",NettobalansIN,51.643008,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.kolk,"Oosterhout, Sluis 1, kolk",Schutten,51.643017,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.pomp1,"Oosterhout, Sluis 1, pomp 1","Oosterhout, Sluis 1, pomp 1",51.643011,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.pomp2,"Oosterhout, Sluis 1, pomp 2","Oosterhout, Sluis 1, pomp 2",51.642997,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.spui,"Oosterhout, Sluis 1, spui",Spuien,51.643,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.spuikanaal,"Oosterhout, sluis 1, spuikanaal","Oosterhout, sluis 1, spuikanaal",51.644,4.8393,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.spuikanaal.kleplinks,"Oosterhout, Sluis 1, spuikanaal, klep links","Oosterhout, Sluis 1, spuikanaal, klep links",51.643006,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.spuikanaal.kleprechts,"Oosterhout, Sluis 1, spuikanaal, klep rechts","Oosterhout, Sluis 1, spuikanaal, klep rechts",51.643003,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterhout.sluis1.uitlaat,"Oosterhout, Sluis 1, uitlaat",NettobalansUIT,51.643008,4.839742,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterleek,Oosterleek,Oosterleek,52.606788,5.202825,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterom,Oosterom,Oosterom,53.367339,5.339001,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterom.oost,"Oosterom, oost","Oosterom, oost",53.378239,5.451069,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.10,"Oosterschelde, 10","Oosterschelde, 10",51.604528,3.459883,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.11,"Oosterschelde, 11","Oosterschelde, 11",51.64329,3.480331,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.12,"Oosterschelde, 12","Oosterschelde, 12",51.679663,3.590399,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.13,"Oosterschelde, 13","Oosterschelde, 13",51.733324,3.554848,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.14,"Oosterschelde, 14","Oosterschelde, 14",51.720117,3.676908,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.15,"Oosterschelde, 15","Oosterschelde, 15",51.582828,3.471022,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.4,"Oosterschelde, 4",voorheen Schaar,51.65514,3.69342,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.9,"Oosterschelde, 09","Oosterschelde, 09",51.623848,3.663128,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.roompotsluis.binnen,Oosterschelde Roompotsluis binnen,Oosterschelde Roompotsluis binnen,51.618,3.688,,,Netherlands,Rijkswaterstaat WaterWebservices
+oosterschelde.roompotsluis.buiten,Oosterschelde Roompotsluis buiten,Oosterschelde Roompotsluis buiten,51.619,3.68,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostfriesegaatje,Oostfriese Gaatje,Oostfriese Gaatje,53.375185,6.95832,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostfriesegaatje.midden,"Oostfriese Gaatje, midden","Oostfriese Gaatje, midden",53.390853,6.990011,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostfriesegaatje.noord,"Oostfriese Gaatje, noord","Oostfriese Gaatje, noord",53.434134,6.916686,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostkapelle,Oostkapelle,Oostkapelle,51.591465,3.555529,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostkapelleduinweg.badstrand,"Oostkapelle Duinweg, badstrand","Oostkapelle Duinweg, badstrand",51.583776,3.54112,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostmahorn,Oostmahorn,Oostmahorn,53.3798,6.162597,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostmeep,Oost Meep,Oost Meep,53.311314,5.410762,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostmeep.oost,"Oost Meep, oost","Oost Meep, oost",53.293331,5.446894,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostmeep.west,"Oost Meep, west","Oost Meep, west",53.322994,5.358695,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostoever,Oostoever,Oostoever,52.93414,4.792286,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostvaardersdiep,Oostvaardersdiep,Oostvaardersdiep,52.418036,5.220809,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostvoorne,Oostvoorne,Oostvoorne,51.92553,4.103611,,,Netherlands,Rijkswaterstaat WaterWebservices
+oostvoorne.badstrand,"Oostvoorne, badstrand","Oostvoorne, badstrand",51.911163,4.048644,,,Netherlands,Rijkswaterstaat WaterWebservices
+opperduit.lek,Opperduit Lek,Opperduit Lek,51.8962802,4.7198061,,,Netherlands,Rijkswaterstaat WaterWebservices
+oranjeplaat.badstrand,"Oranjeplaat, badstrand","Oranjeplaat, badstrand",51.51678,3.706816,,,Netherlands,Rijkswaterstaat WaterWebservices
+oranjesluizen.oost,"Oranjesluizen, oost","Oranjesluizen, oost",52.381617,4.961275,,,Netherlands,Rijkswaterstaat WaterWebservices
+oranjesluizen.west,"Oranjesluizen, west","Oranjesluizen, west",52.382238,4.959066,,,Netherlands,Rijkswaterstaat WaterWebservices
+oranjezon,Oranjezon,Oranjezon,51.596793,3.574369,,,Netherlands,Rijkswaterstaat WaterWebservices
+ossenisse,Ossenisse,vh Overloop van Hansweert,51.407884,3.966769,,,Netherlands,Rijkswaterstaat WaterWebservices
+oterdum,Oterdum,Oterdum,53.31268,7.019246,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudbeijerland,Oud Beijerland,km 999,51.825528,4.385572,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudbeijerland.badstrand,"Oud Beijerland, badstrand","Oud Beijerland, badstrand",51.830109,4.395771,,,Netherlands,Rijkswaterstaat WaterWebservices
+ouddorp,Ouddorp,Ouddorp,51.797831,3.929932,,,Netherlands,Rijkswaterstaat WaterWebservices
+ouddorp.depunt.grevelingen,"Ouddorp, De Punt, Grevelingen","Ouddorp, De Punt, Grevelingen",51.780095,3.885069,,,Netherlands,Rijkswaterstaat WaterWebservices
+ouddorp.diepeput,"Ouddorp, diepe put","Ouddorp, diepe put",51.796183,3.934769,,,Netherlands,Rijkswaterstaat WaterWebservices
+ouddorp.strand,"Ouddorp, strand","Ouddorp, strand",51.831487,3.925506,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudemirdum,Oude Mirdum,Oude Mirdum,52.822004,5.467314,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudemirdum.ijsselmeer.noordoost.meetpaal9,"Oude Mirdum, IJsselmeer, noordoost, meetpaal 09","Oude Mirdum, IJsselmeer, noordoost, meetpaal 09",52.810189,5.48847,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudemirdum.ijsselmeer.noordoost.meetpaalfl05,"Oude Mirdum, IJsselmeer, noordoost, meetpaal FL05",voorheen Friesche Kust,52.836389,5.512037,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudetonge.badstrand,"Oude-Tonge, badstrand","Oude-Tonge, badstrand",51.676415,4.207675,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudewestereems,Oude Westereems,Oude Westereems,53.496162,6.697226,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudewestereems.noord,"Oude Westereems, noord","Oude Westereems, noord",53.528384,6.662908,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudezeug,Oude Zeug,Oude Zeug,52.859168,5.103472,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudezeug.ijsselmeer.midden.noord.meetpaal47,"Oude Zeug, IJsselmeer , midden, noord, meetpaal 47","Oude Zeug, IJsselmeer , midden, noord, meetpaal 47",52.91201,5.223985,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudezeug.ijsselmeer.midden.noord.meetpaal48,"Oude Zeug, IJsselmeer , midden, noord, meetpaal 48","Oude Zeug, IJsselmeer , midden, noord, meetpaal 48",52.87351,5.118499,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudezeug.ijsselmeer.midden.noord.meetpaal49,"Oude Zeug, IJsselmeer , midden, noord, meetpaal 49","Oude Zeug, IJsselmeer , midden, noord, meetpaal 49",52.870143,5.108064,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudnaarden,Oud Naarden,Oud Naarden,52.324849,5.230986,,,Netherlands,Rijkswaterstaat WaterWebservices
+oudvalkeveen,Oud-Valkeveen,Oud-Valkeveen,52.308327,5.193257,,,Netherlands,Rijkswaterstaat WaterWebservices
+ouwerkerk.hoekvanouwerkerk.badstrand,"Ouwerkerk, Hoek van Ouwerkerk, badstrand","Ouwerkerk, Hoek van Ouwerkerk, badstrand",51.616176,3.961335,,,Netherlands,Rijkswaterstaat WaterWebservices
+overasseltii,Overasselt II,Overasselt II,51.754895,5.793547,,,Netherlands,Rijkswaterstaat WaterWebservices
+overlaatcontelmo,Overlaat contelmo,Overlaat contelmo,51.091668,5.824927,,,Netherlands,Rijkswaterstaat WaterWebservices
+paap,Paap,Paap,53.348944,6.944522,,,Netherlands,Rijkswaterstaat WaterWebservices
+paardenboer,Paardenboer,Paardenboer,52.611716,5.957832,,,Netherlands,Rijkswaterstaat WaterWebservices
+pampus.oost,"Pampus, oost","Pampus, oost",52.366482,5.087658,,,Netherlands,Rijkswaterstaat WaterWebservices
+pampus.west,"Pampus, west","Pampus, west",52.363683,5.059078,,,Netherlands,Rijkswaterstaat WaterWebservices
+panheel.gemaal,"Panheel, gemaal","Panheel, gemaal",51.176547,5.8563,,,Netherlands,Rijkswaterstaat WaterWebservices
+panheel.sluis.boven,"Panheel, sluis, boven","Panheel, sluis, boven",51.165552,5.86185,,,Netherlands,Rijkswaterstaat WaterWebservices
+panheel.sluis.inlaat,"Panheel, sluis, inlaat",NettobalansIN,51.176542,5.8563,,,Netherlands,Rijkswaterstaat WaterWebservices
+panheel.sluis.pomp1,"Panheel, sluis, pomp 1","Panheel, sluis, pomp 1",51.17655,5.8563,,,Netherlands,Rijkswaterstaat WaterWebservices
+panheel.sluis.pomp2,"Panheel, sluis, pomp 2","Panheel, sluis, pomp 2",51.176553,5.8563,,,Netherlands,Rijkswaterstaat WaterWebservices
+panheel.sluis.uitlaat,"Panheel, sluis, uitlaat",NettobalansUIT,51.176542,5.8563,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannengat.boei1,"Pannengat, boei 1","Pannengat, boei 1",53.243317,5.19098,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal,"Pannerden, Pannerdensch kanaal","Pannerden, Pannerdensch kanaal",51.87475,6.03778,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km868p000.ro,"Pannerden, Pannerdensch kanaal, km. 868.000 , ro","Pannerden, Pannerdensch kanaal, km. 868.000 , ro",51.877802,6.035638,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km870p000.ro,"Pannerden, Pannerdensch kanaal, km. 870.000 , ro","Pannerden, Pannerdensch kanaal, km. 870.000 , ro",51.894273,6.024725,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km872p800.ro,"Pannerden, Pannerdensch kanaal, km. 872.800 , ro","Pannerden, Pannerdensch kanaal, km. 872.800 , ro",51.9093,5.996963,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km876p400.lo,"Pannerden, Pannerdensch kanaal, km. 876.400 , lo","Pannerden, Pannerdensch kanaal, km. 876.400 , lo",51.932389,5.962048,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km877p500.lo,"Pannerden, Pannerdensch kanaal, km. 877.500 , lo","Pannerden, Pannerdensch kanaal, km. 877.500 , lo",51.942017,5.95922,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km877p500.ro,"Pannerden, Pannerdensch kanaal, km. 877.500 , ro","Pannerden, Pannerdensch kanaal, km. 877.500 , ro",51.94304,5.962631,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km878p000.lo,"Pannerden, Pannerdensch kanaal, km. 878.000 , lo","Pannerden, Pannerdensch kanaal, km. 878.000 , lo",51.946337,5.955997,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km878p000.ro,"Pannerden, Pannerdensch kanaal, km. 878.000 , ro","Pannerden, Pannerdensch kanaal, km. 878.000 , ro",51.948031,5.958786,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km878p500.lo,"Pannerden, Pannerdensch kanaal, km. 878.500 , lo","Pannerden, Pannerdensch kanaal, km. 878.500 , lo",51.949818,5.950763,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.pannerdenschkanaal.km878p500.ro,"Pannerden, Pannerdensch kanaal, km. 878.500 , ro","Pannerden, Pannerdensch kanaal, km. 878.500 , ro",51.951216,5.953895,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.regelwerk.beneden,"Pannerden, regelwerk, beneden","Pannerden, regelwerk, beneden",51.888635,6.029691,,,Netherlands,Rijkswaterstaat WaterWebservices
+pannerden.regelwerk.boven,"Pannerden, regelwerk, boven","Pannerden, regelwerk, boven",51.888013,6.030013,,,Netherlands,Rijkswaterstaat WaterWebservices
+papenbeek.leukermeer.recreatiestrandvakantiepark,"Papenbeek, Leukermeer, Recreatiestrand Vakantiepark","Papenbeek, Leukermeer, Recreatiestrand Vakantiepark",51.567382,6.062421,,,Netherlands,Rijkswaterstaat WaterWebservices
+papendrecht,Papendrecht,km 972.5,51.822533,4.723611,,,Netherlands,Rijkswaterstaat WaterWebservices
+parksluis,Parksluis,Parksluis,51.906535,4.464452,,,Netherlands,Rijkswaterstaat WaterWebservices
+pasvanrilland.boei81a,"Pas van Rilland, boei 81A","Pas van Rilland, boei 81A",51.380516,4.211838,,,Netherlands,Rijkswaterstaat WaterWebservices
+pauluszand,Pauluszand,Pauluszand,51.762329,4.860298,,,Netherlands,Rijkswaterstaat WaterWebservices
+perkpolder.badstrand,"Perkpolder, badstrand","Perkpolder, badstrand",51.401619,4.016338,,,Netherlands,Rijkswaterstaat WaterWebservices
+perkpolder.walsoorden,"Perkpolder, Walsoorden","Perkpolder, Walsoorden",51.398845,4.017427,,,Netherlands,Rijkswaterstaat WaterWebservices
+pernis,Pernis,km 1008,51.896583,4.390528,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten,Petten,Petten,52.78839,4.664854,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.5kmuitdekust,"Petten, 5 km uit de kust","Petten, 5 km uit de kust",52.831866,4.615138,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai16,"Petten, meetraai 16","Petten, meetraai 16",52.771999,4.651892,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai17,"Petten, meetraai 17","Petten, meetraai 17",52.771401,4.65405,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai18,"Petten, meetraai 18","Petten, meetraai 18",52.771159,4.655551,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai3,"Petten, meetraai 03","Petten, meetraai 03",52.772884,4.649758,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai6,"Petten, meetraai 06","Petten, meetraai 06",52.77083,4.656149,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai67,"Petten, meetraai 67","Petten, meetraai 67",52.77076,4.656432,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai7,"Petten, meetraai 07","Petten, meetraai 07",52.770636,4.656745,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.meetraai8,"Petten, meetraai 08","Petten, meetraai 08",52.770538,4.656999,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.strand,"Petten, strand","Petten, strand",52.775785,4.661061,,,Netherlands,Rijkswaterstaat WaterWebservices
+petten.zuid,"Petten, zuid","Petten, zuid",52.772659,4.649702,,,Netherlands,Rijkswaterstaat WaterWebservices
+philipsdam.oost,"Philipsdam, oost","Philipsdam, oost",51.661678,4.195802,,,Netherlands,Rijkswaterstaat WaterWebservices
+philipsdam.west,"Philipsdam, west","Philipsdam, west",51.665512,4.149443,,,Netherlands,Rijkswaterstaat WaterWebservices
+pieterburenwad,Pieterburenwad,1,53.457101,6.453042,,,Netherlands,Rijkswaterstaat WaterWebservices
+plaatvanoudetonge.oost,"Plaat van Oude Tonge, oost","Plaat van Oude Tonge, oost",51.672527,4.13955,,,Netherlands,Rijkswaterstaat WaterWebservices
+plasvanwijck.heteren,"Plas van Wijck, Heteren","Plas van Wijck, Heteren",51.963229,5.752846,,,Netherlands,Rijkswaterstaat WaterWebservices
+plaswrceijsden,Plas WRC Eijsden,Hoge Weerd,50.818162,5.699367,,,Netherlands,Rijkswaterstaat WaterWebservices
+plaswrceijsden.oostmaarland.noord,"Plas WRC Eijsden, Oost Maarland, noord","Plas WRC Eijsden, Oost Maarland, noord",50.807845,5.705312,,,Netherlands,Rijkswaterstaat WaterWebservices
+poeldonk.aa.inlaat,"Poeldonk, Aa, inlaat",Spuien,51.68365,5.353944,,,Netherlands,Rijkswaterstaat WaterWebservices
+poeldonk.aa.schuif.links,"Poeldonk, Aa, schuif, links","Poeldonk, Aa, schuif, links",51.683644,5.353944,,,Netherlands,Rijkswaterstaat WaterWebservices
+poeldonk.aa.schuif.rechts,"Poeldonk, Aa, schuif, rechts","Poeldonk, Aa, schuif, rechts",51.683647,5.353944,,,Netherlands,Rijkswaterstaat WaterWebservices
+poeldonk.aa.uitlaat,"Poeldonk, Aa, uitlaat",NettobalansUIT,51.683644,5.353944,,,Netherlands,Rijkswaterstaat WaterWebservices
+poeldonk.dungensebrug,"Poeldonk, Dungense Brug","Poeldonk, Dungense Brug",51.680673,5.368564,,,Netherlands,Rijkswaterstaat WaterWebservices
+pogum,Pogum,Pogum,53.321485,7.253999,,,Netherlands,Rijkswaterstaat WaterWebservices
+polingangkwn,Pol-ingang KWN,Pol-ingang KWN,51.166167,5.892948,,,Netherlands,Rijkswaterstaat WaterWebservices
+pollendam,Pollendam,Pollendam,53.192574,5.339854,,,Netherlands,Rijkswaterstaat WaterWebservices
+poortershaven.ro,"Poortershaven, ro",km 1023.1,51.940318,4.202026,,,Netherlands,Rijkswaterstaat WaterWebservices
+poortugaal,Poortugaal,km 998,51.842247,4.396084,,,Netherlands,Rijkswaterstaat WaterWebservices
+portaisola,Porta Isola,Porta Isola,51.134037,5.855281,,,Netherlands,Rijkswaterstaat WaterWebservices
+pottengat,Pottengat,Pottengat,52.637245,5.323093,,,Netherlands,Rijkswaterstaat WaterWebservices
+prosperpolder,Prosperpolder,Prosperpolder,51.340042,4.265944,,,Netherlands,Rijkswaterstaat WaterWebservices
+puttershoek,Puttershoek,Puttershoek,51.811648,4.565993,,,Netherlands,Rijkswaterstaat WaterWebservices
+q1.1,Q1 platform,Q1 platform,52.925335,4.150361,,,Netherlands,Rijkswaterstaat WaterWebservices
+raamsdonksveer,Raamsdonksveer,Donge,51.681731,4.877359,,,Netherlands,Rijkswaterstaat WaterWebservices
+raamsdonkveerbrughillen,Raamsdonkveer brug Hillen,Raamsdonkveer brug Hillen,51.682081,4.855087,,,Netherlands,Rijkswaterstaat WaterWebservices
+ramsdiep,Ramsdiep,kilometer 10,52.630065,5.931705,,,Netherlands,Rijkswaterstaat WaterWebservices
+ramspolbrug.ramsdiep,"Ramspolbrug, Ramsdiep","Ramspolbrug, Ramsdiep",52.612666,5.841944,,,Netherlands,Rijkswaterstaat WaterWebservices
+ramspolkering.ketelmeer,Ramspolkering Ketelmeerzijde,0,52.610468,5.84081401,,,Netherlands,Rijkswaterstaat WaterWebservices
+ranselgat,Ranselgat,Ranselgat,53.527608,6.723824,,,Netherlands,Rijkswaterstaat WaterWebservices
+ranselgat.zuid,"Ranselgat, zuid","Ranselgat, zuid",53.493937,6.810293,,,Netherlands,Rijkswaterstaat WaterWebservices
+ravenstein,Ravenstein,Ravenstein,51.79596,5.658714,,,Netherlands,Rijkswaterstaat WaterWebservices
+ravenstein.beneden.spoorbrug,"Ravenstein, beneden, Spoorbrug","Ravenstein, beneden, Spoorbrug",51.802374,5.654068,,,Netherlands,Rijkswaterstaat WaterWebservices
+ravenswaay.beneden,"Ravenswaay, beneden",ARK km 63.5,51.946648,5.376294,,,Netherlands,Rijkswaterstaat WaterWebservices
+razernijpolder,Razernijpolder,Razernijpolder,51.506544,4.206926,,,Netherlands,Rijkswaterstaat WaterWebservices
+recreatiegebiedmookerplas,Recreatiegebied Mookerplas,Recreatiegebied Mookerplas,51.732233,5.929823,,,Netherlands,Rijkswaterstaat WaterWebservices
+recreatiegebieduiterdijkschellinkhout,Recreatiegebied Uiterdijk Schellinkhout,Recreatiegebied Uiterdijk Schellinkhout,52.63273,5.120501,,,Netherlands,Rijkswaterstaat WaterWebservices
+recreatieoordveluwestrandbad,Recreatieoord Veluwe Strandbad,Recreatieoord Veluwe Strandbad,52.453215,5.821841,,,Netherlands,Rijkswaterstaat WaterWebservices
+recreatieparkdescherpenhof,Recreatiepark De Scherpenhof,Recreatiepark De Scherpenhof,52.298177,6.099814,,,Netherlands,Rijkswaterstaat WaterWebservices
+recreatieterreinhellegatsplein,Recreatieterrein Hellegatsplein,Recreatieterrein Hellegatsplein,51.705842,4.398554,,,Netherlands,Rijkswaterstaat WaterWebservices
+redichemsewaard,Redichemse Waard,recreatieplas,51.975318,5.238752,,,Netherlands,Rijkswaterstaat WaterWebservices
+reevediep,Reevediep,Reevediep,52.527562,5.893674,,,Netherlands,Rijkswaterstaat WaterWebservices
+reide,Reide,Reide,53.309315,7.096425,,,Netherlands,Rijkswaterstaat WaterWebservices
+remmerden,Remmerden,Remmerden,51.969655,5.535344,,,Netherlands,Rijkswaterstaat WaterWebservices
+renesse.badstrand.j.vanrenessewegbadstrand,"Renesse, badstrand, J. van Renesseweg badstrand","Renesse, badstrand, J. van Renesseweg badstrand",51.74224,3.763166,,,Netherlands,Rijkswaterstaat WaterWebservices
+renesse.badstrand.luieweg,"Renesse, badstrand, Luieweg","Renesse, badstrand, Luieweg",51.739668,3.750863,,,Netherlands,Rijkswaterstaat WaterWebservices
+reve,Reve,Reve,52.517857,5.860605,,,Netherlands,Rijkswaterstaat WaterWebservices
+rhederlaag.bahrschestrand,"Rhederlaag, Bahrsche Strand","Rhederlaag, Bahrsche Strand",51.987341,6.041818,,,Netherlands,Rijkswaterstaat WaterWebservices
+rhederlaag.giesekop,"Rhederlaag, Giese Kop","Rhederlaag, Giese Kop",51.992371,6.058402,,,Netherlands,Rijkswaterstaat WaterWebservices
+rhederlaag.lathumsehoek,"Rhederlaag, Lathumse Hoek",recreatieplas,51.988441,6.037961,,,Netherlands,Rijkswaterstaat WaterWebservices
+rhederlaag.noordoever,"Rhederlaag, Noordoever","Rhederlaag, Noordoever",52.002495,6.046758,,,Netherlands,Rijkswaterstaat WaterWebservices
+rhenen.grebbeberg,Rhenen Grebbeberg,Rhenen Grebbeberg,51.949389,5.589806,,,Netherlands,Rijkswaterstaat WaterWebservices
+rietplaat,Rietplaat,Rietplaat,51.747494,4.776338,,,Netherlands,Rijkswaterstaat WaterWebservices
+rietplaat.badstrand,"Rietplaat, badstrand","Rietplaat, badstrand",51.748397,4.776977,,,Netherlands,Rijkswaterstaat WaterWebservices
+rietweg,Rietweg,Larsertocht,52.435452,5.566606,,,Netherlands,Rijkswaterstaat WaterWebservices
+rijswijk.drielandenpunt,Rijswijk Drielandenpunt,Rijswijk Drielandenpunt,51.95187,5.35958,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.antwerpskanaalpand,"Rilland, Antwerps kanaalpand",linker oever km 1042,51.405709,4.237887,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.bath,"Rilland, Bath","Rilland, Bath",51.39878,4.21014,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.bathsebrug,"Rilland, Bathsebrug",voorheen Kreekrakbrug spuikanaal,51.42503,4.231181,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.bathsespuikanaal.inloop,"Rilland, Bathse Spuikanaal, inloop","Rilland, Bathse Spuikanaal, inloop",51.46291,4.22577,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.bathsespuisluis,Rilland Bathse spuisluis,Rilland Bathse spuisluis,51.3931,4.23458,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.bathsespuisluis.binnen,Rilland Bathse spuisluis binnen,Rilland Bathse spuisluis binnen,51.393198,4.235008,,,Netherlands,Rijkswaterstaat WaterWebservices
+rilland.bathsespuisluis.buiten,Rilland Bathse spuisluis buiten,Rilland Bathse spuisluis buiten,51.39283,4.234155,,,Netherlands,Rijkswaterstaat WaterWebservices
+ritthem.fortrammekens.badstrand,"Ritthem, Fort Rammekens, badstrand","Ritthem, Fort Rammekens, badstrand",51.451945,3.656545,,,Netherlands,Rijkswaterstaat WaterWebservices
+rivierabeach.noord,"Riviera Beach, noord","Riviera Beach, noord",52.448052,5.805669,,,Netherlands,Rijkswaterstaat WaterWebservices
+rivierabeach.zuid,"Riviera Beach, Zuid","Riviera Beach, Zuid",52.442927,5.800884,,,Netherlands,Rijkswaterstaat WaterWebservices
+robbengat,Robbengat,Robbengat,53.454579,6.485632,,,Netherlands,Rijkswaterstaat WaterWebservices
+robbenplaat,Robbenplaat,Robbenplaat,53.435463,6.893198,,,Netherlands,Rijkswaterstaat WaterWebservices
+rockanje.2eslag,"Rockanje, 2e Slag","Rockanje, 2e Slag",51.867792,4.048874,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond,Roermond,monding van de Roer,51.196378,5.982344,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.beneden,"Roermond, beneden","Roermond, beneden",51.213466,5.980419,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.boven,"Roermond, boven","Roermond, boven",51.2005,5.9815,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.deweerd.noorderplas,"Roermond, De Weerd, noorderplas",dagstrand,51.208666,5.969767,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.doevesbeemd.noord,"Roermond, Doevesbeemd, noord",camping van Ass,51.208545,5.976062,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.doevesbeemd.noord.2,"Roermond, Doevesbeemd, noord, 2",campings,51.207193,5.97676,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.doevesbeemd.west,"Roermond, Doevesbeemd, west",camping Hermans,51.208435,5.976361,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.hambeek,"Roermond, Hambeek","Roermond, Hambeek",51.184693,5.982192,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.recreatiestrandcampinghatenboer,"Roermond, Recreatiestrand Camping Hatenboer","Roermond, Recreatiestrand Camping Hatenboer",51.195627,5.97448,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.resortmarinaoolderhuuske.recreatiestrand,"Roermond, Resort Marina Oolderhuuske, recreatiestrand","Roermond, Resort Marina Oolderhuuske, recreatiestrand",51.190285,5.954914,,,Netherlands,Rijkswaterstaat WaterWebservices
+roermond.stuw.boven,"Roermond, stuw, boven","Roermond, stuw, boven",51.21073,5.982902,,,Netherlands,Rijkswaterstaat WaterWebservices
+roeven.sluis15.aftapduiker,Roeven Sluis15 aftapduiker,Roeven Sluis15 aftapduiker,51.27261399,5.75118405,,,Netherlands,Rijkswaterstaat WaterWebservices
+roeven.sluis15.schuiflinks,Roeven Sluis15 schuiflinks,Roeven Sluis15 schuiflinks,51.27261399,5.75118405,,,Netherlands,Rijkswaterstaat WaterWebservices
+roeven.sluis15.schuifrechts,Roeven Sluis15 schuifrechts,Roeven Sluis15 schuifrechts,51.27261399,5.75118405,,,Netherlands,Rijkswaterstaat WaterWebservices
+roeven.sluis15.wkcoverstort,Roeven Sluis15 WKCoverstort,Roeven Sluis15 WKCoverstort,51.27264534,5.74977995,,,Netherlands,Rijkswaterstaat WaterWebservices
+roeven.sluis15.wkcspui,Roeven Sluis15 WKCspui,Roeven Sluis15 WKCspui,51.27264534,5.74977995,,,Netherlands,Rijkswaterstaat WaterWebservices
+roggenplaatgeulwest,Roggenplaat geul west,Roggenplaat geul west,51.645561,3.760565,,,Netherlands,Rijkswaterstaat WaterWebservices
+roompot.bekken,"Roompot, bekken","Roompot, bekken",51.618314,3.69667,,,Netherlands,Rijkswaterstaat WaterWebservices
+roptazijl,Roptazijl,Roptazijl,53.210131,5.4369,,,Netherlands,Rijkswaterstaat WaterWebservices
+rosmalen.hintham.beneden,"Rosmalen, Hintham, beneden","Rosmalen, Hintham, beneden",51.700278,5.358111,,,Netherlands,Rijkswaterstaat WaterWebservices
+rosmalen.hintham.boven,"Rosmalen, Hintham, boven","Rosmalen, Hintham, boven",51.696961,5.359169,,,Netherlands,Rijkswaterstaat WaterWebservices
+rosmalen.hinthamsluis.beneden,Rosmalen Hinthamsluis beneden,Rosmalen Hinthamsluis beneden,51.700277,5.358111,,,Netherlands,Rijkswaterstaat WaterWebservices
+rosmalen.hinthamsluis.boven,Rosmalen Hinthamsluis boven,Rosmalen Hinthamsluis boven,51.697111,5.359194,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotem,Rotem,Rotem,51.0506,5.771,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdam.brienenoordbrug,"Rotterdam, Brienenoordbrug",rechter oever kilometer 995.2,51.90525,4.542468,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdam.dintelhaven,"Rotterdam, Dintelhaven","Rotterdam, Dintelhaven",51.954265,4.120655,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdam.ijzerwerkerkade,Rotterdam IJzerwerkerkade,Radarpost 23,51.89947,4.51838,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdam.kuip,Rotterdam Kuip,Rotterdam Kuip,51.899467,4.518375,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdam.lekhaven,"Rotterdam, Lekhaven",rechter oever km 1005.2,51.904099,4.429597,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdam.nieuwemaas.boerengat,"Rotterdam, Nieuwe Maas, Boerengat","Rotterdam, Nieuwe Maas, Boerengat",51.9184,4.5003,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdamsehoek,Rotterdamse Hoek,Rotterdamse Hoek,52.760831,5.533865,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdamsehoek.ijsselmeer,Rotterdamsehoek IJsselmeer,Rotterdamsehoek IJsselmeer,52.748722,5.552,,,Netherlands,Rijkswaterstaat WaterWebservices
+rotterdamsehoek.meetpaalfl2,"Rotterdamse Hoek, meetpaal FL2","Rotterdamse Hoek, meetpaal FL2",52.748229,5.550114,,,Netherlands,Rijkswaterstaat WaterWebservices
+rozenburgsesluis.noordzijde,"Rozenburgsesluis, noordzijde","Rozenburgsesluis, noordzijde",51.895774,4.228892,,,Netherlands,Rijkswaterstaat WaterWebservices
+rozenburgsesluis.zuidzijde,"Rozenburgsesluis, zuidzijde","Rozenburgsesluis, zuidzijde",51.891244,4.229823,,,Netherlands,Rijkswaterstaat WaterWebservices
+runderweg,Runderweg,Oostervaart,52.519541,5.524222,,,Netherlands,Rijkswaterstaat WaterWebservices
+runkampen,Runkampen,Aa,51.68302,5.382719,,,Netherlands,Rijkswaterstaat WaterWebservices
+saeftinge.boei76,"Saeftinge, boei 76","Saeftinge, boei 76",51.367093,4.217928,,,Netherlands,Rijkswaterstaat WaterWebservices
+sambeek.beneden,"Sambeek, beneden","Sambeek, beneden",51.6458,5.972,,,Netherlands,Rijkswaterstaat WaterWebservices
+sambeek.boven,"Sambeek, boven","Sambeek, boven",51.63225,6.0036,,,Netherlands,Rijkswaterstaat WaterWebservices
+sasvangent,Sas van Gent,noordzijde brug,51.230267,3.807499,,,Netherlands,Rijkswaterstaat WaterWebservices
+sasvangent.grens,"Sas van Gent, grens","Sas van Gent, grens",51.210291,3.802218,,,Netherlands,Rijkswaterstaat WaterWebservices
+schaar.stroomgat,Schaar Stroomgat,Schaar Stroomgat,51.65163,3.09968,,,Netherlands,Rijkswaterstaat WaterWebservices
+schaarvandenoord,Schaar van de Noord,Schaar van de Noord,51.377868,4.164992,,,Netherlands,Rijkswaterstaat WaterWebservices
+schaarvanoudendoel,Schaar van Ouden Doel,Schaar van Ouden Doel,51.350292,4.250659,,,Netherlands,Rijkswaterstaat WaterWebservices
+schaarvanspijkerplaat.vlissingen,"Schaar van Spijkerplaat, Vlissingen","Schaar van Spijkerplaat, Vlissingen",51.429896,3.631034,,,Netherlands,Rijkswaterstaat WaterWebservices
+schaarvanwaarde.boeisvw3,"Schaar van Waarde, boei SVW3","Schaar van Waarde, boei SVW3",51.414287,4.038815,,,Netherlands,Rijkswaterstaat WaterWebservices
+schanskerdiep,Schanskerdiep,Schanskerdiep,53.25955,7.165377,,,Netherlands,Rijkswaterstaat WaterWebservices
+scharendijke.diepeput,"Scharendijke, diepe put","Scharendijke, diepe put",51.742883,3.848149,,,Netherlands,Rijkswaterstaat WaterWebservices
+scharendijke.ellemeetbadstrand,"Scharendijke, Ellemeet badstrand","Scharendijke, Ellemeet badstrand",51.740741,3.818102,,,Netherlands,Rijkswaterstaat WaterWebservices
+scharendijke.repart,"Scharendijke, Repart","Scharendijke, Repart",51.739664,3.831751,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheelhoek,Scheelhoek,Scheelhoek,51.812052,4.080231,,,Netherlands,Rijkswaterstaat WaterWebservices
+schellingwoude,Schellingwoude,Schellingwoude,52.342823,4.996866,,,Netherlands,Rijkswaterstaat WaterWebservices
+schellingwoude.h1,"Schellingwoude, H1","Schellingwoude, H1",52.381062,4.959386,,,Netherlands,Rijkswaterstaat WaterWebservices
+schellingwoude.inlaatsluis,"Schellingwoude, inlaatsluis","Schellingwoude, inlaatsluis",52.38137,4.960161,,,Netherlands,Rijkswaterstaat WaterWebservices
+schellinkhouterdijk.hoorn,"Schellinkhouterdijk, Hoorn","Schellinkhouterdijk, Hoorn",52.641219,5.077931,,,Netherlands,Rijkswaterstaat WaterWebservices
+schenkeldijk,Schenkeldijk,kilometer 986,51.744218,4.630642,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheurhaven,Scheurhaven,Scheurhaven,51.962297,4.138792,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheurwest,Scheur west,Scheur west,51.40926,3.269829,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen,Scheveningen,Scheveningen,52.099035,4.263563,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.33kmuitdekust,"Scheveningen, 33 km uit de kust","Scheveningen, 33 km uit de kust",52.31866,3.909522,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.3kmuitdekust,"Scheveningen, 3 km uit de kust","Scheveningen, 3 km uit de kust",52.153659,4.275369,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.buitenhaven,"Scheveningen, buitenhaven","Scheveningen, buitenhaven",52.098721,4.258827,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.gemaalschouteverversingskanaal,"Scheveningen, Gemaal Schoute verversingskanaal","Scheveningen, Gemaal Schoute verversingskanaal",52.089999,4.267029,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.noorderstrand,"Scheveningen, Noorderstrand","Scheveningen, Noorderstrand",52.111263,4.273329,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.vuurtorenbadstrand,"Scheveningen, vuurtoren badstrand","Scheveningen, vuurtoren badstrand",52.109391,4.265492,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.zuiderstrand,"Scheveningen, Zuiderstrand","Scheveningen, Zuiderstrand",52.091658,4.246922,,,Netherlands,Rijkswaterstaat WaterWebservices
+scheveningen.zwartepad,"Scheveningen, Zwarte Pad","Scheveningen, Zwarte Pad",52.122688,4.293488,,,Netherlands,Rijkswaterstaat WaterWebservices
+schiermonnikoog.eilanderbalg,Schiermonnikoog.Eilanderbalg,Schiermonnikoog.Eilanderbalg,53.474708,6.335251,,,Netherlands,Rijkswaterstaat WaterWebservices
+schiermonnikoog.noord,"Schiermonnikoog, noord","Schiermonnikoog, noord",53.594837,6.165377,,,Netherlands,Rijkswaterstaat WaterWebservices
+schiermonnikoog.waddenzee,"Schiermonnikoog, Waddenzee","Schiermonnikoog, Waddenzee",53.468937,6.202908,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel,Schijndel,Schijndel,51.648769,5.443422,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis,Schijndel sluis,Schijndel sluis,51.648581,5.443581,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.beneden,"Schijndel, sluis, beneden","Schijndel, sluis, beneden",51.648831,5.442469,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.boven,"Schijndel, sluis, boven","Schijndel, sluis, boven",51.648347,5.445819,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.inlaat,"Schijndel, sluis, inlaat",Spuien,51.648317,5.443467,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.kleplinks,Schijndel sluis kleplinks,Schijndel sluis kleplinks,51.64831172,5.44346528,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.kleprechts,Schijndel sluis kleprechts,Schijndel sluis kleprechts,51.64831172,5.44346528,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.kolk,Schijndel sluis kolk,Schijndel sluis kolk,51.64834651,5.44582047,,,Netherlands,Rijkswaterstaat WaterWebservices
+schijndel.sluis.spuikanaal,"Schijndel, sluis, spuikanaal","Schijndel, sluis, spuikanaal",51.648311,5.443464,,,Netherlands,Rijkswaterstaat WaterWebservices
+schildnoord,Schild noord,Schild noord,53.54028,6.551049,,,Netherlands,Rijkswaterstaat WaterWebservices
+schokkerhaven,Schokkerhaven,Schokkerhaven,52.608294,5.754798,,,Netherlands,Rijkswaterstaat WaterWebservices
+schokkerhaven.strand,"Schokkerhaven, strand","Schokkerhaven, strand",52.612048,5.7438,,,Netherlands,Rijkswaterstaat WaterWebservices
+schokland,Schokland,Schokland,52.625507,5.768233,,,Netherlands,Rijkswaterstaat WaterWebservices
+schoonhoven,Schoonhoven,Schoonhoven,51.942,4.85,,,Netherlands,Rijkswaterstaat WaterWebservices
+schore,Schore,Schore,52.957356,4.9445,,,Netherlands,Rijkswaterstaat WaterWebservices
+schoreloswal,Schore loswal,Schore loswal,51.462993,4.006431,,,Netherlands,Rijkswaterstaat WaterWebservices
+schotsmancampenswegbadstrand,Schotsman Campensweg badstrand,Schotsman Campensweg badstrand,51.574656,3.649992,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.10kmuitdekust,"Schouwen, 10 km uit de kust","Schouwen, 10 km uit de kust",51.719192,3.493973,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.1kmuitdekust,"Schouwen, 1 km uit de kust","Schouwen, 1 km uit de kust",51.665744,3.593157,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.20kmuitdekust,"Schouwen, 20 km uit de kust","Schouwen, 20 km uit de kust",51.778637,3.385635,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.30kmuitdekust,"Schouwen, 30 km uit de kust","Schouwen, 30 km uit de kust",51.839054,3.2732,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.4kmuitdekust,"Schouwen, 4 km uit de kust","Schouwen, 4 km uit de kust",51.682408,3.561489,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.50kmuitdekust,"Schouwen, 50 km uit de kust","Schouwen, 50 km uit de kust",51.954042,3.056841,,,Netherlands,Rijkswaterstaat WaterWebservices
+schouwen.70kmuitdekust,"Schouwen, 70 km uit de kust","Schouwen, 70 km uit de kust",52.073475,2.829111,,,Netherlands,Rijkswaterstaat WaterWebservices
+schroevendplas,Schroevend Plas,Schroevend Plas,51.109777,5.819246,,,Netherlands,Rijkswaterstaat WaterWebservices
+schuitengatii,Schuitengat II,Schuitengat II,53.354598,5.219007,,,Netherlands,Rijkswaterstaat WaterWebservices
+schulpengatii,Schulpengat II,Schulpengat II,52.937577,4.679524,,,Netherlands,Rijkswaterstaat WaterWebservices
+schuwacht.lek,"Schuwacht, Lek","Schuwacht, Lek",51.8906101,4.6566256,,,Netherlands,Rijkswaterstaat WaterWebservices
+servaasbrugbeneden,Servaasbrug beneden,Servaasbrug beneden,50.849776,5.696502,,,Netherlands,Rijkswaterstaat WaterWebservices
+sgravendeel,'s-Gravendeel,'s-Gravendeel,51.779153,4.625854,,,Netherlands,Rijkswaterstaat WaterWebservices
+sgravendeel.haven,"'s-Gravendeel, haven","'s-Gravendeel, haven",51.782209,4.625802,,,Netherlands,Rijkswaterstaat WaterWebservices
+sgravenmoer,sgravenmoer,Donge,51.657249,4.934864,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.crevecoeur,'s-Hertogenbosch Crevecoeur,'s-Hertogenbosch Crevecoeur,51.733524,5.271539,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.empel.kanaal,"Empel, kanaal","Empel, kanaal",51.738528,5.333972,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.empel.maas,"Empel, Maas","Empel, Maas",51.740083,5.332889,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.engelen,'s-Hertogenbosch Engelen,vh Crevecoeur boven,51.73365,5.273041,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.engelen.dieze,'s-Hertogenbosch Engelen Dieze,'s-Hertogenbosch Engelen Dieze,51.73361,5.27297,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.poeldonk.aa,"'s-Hertogenbosch, Poeldonk, aa",voorheen beneden,51.683645,5.353944,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.poeldonk.zuidwillemsvaart,"'s-Hertogenbosch, Poeldonk, Zuid-Willemsvaart",voorheen boven,51.683,5.3537,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.gemaal,'s-Hertogenbosch Sluis Empel gemaal,'s-Hertogenbosch Sluis Empel gemaal,51.738519,5.333967,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.inlaat,'s-Hertogenbosch Sluis Empel inlaat,'s-Hertogenbosch Sluis Empel inlaat,51.738522,5.333967,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.pomp1,'s-Hertogenbosch Sluis Empel pomp1,'s-Hertogenbosch Sluis Empel pomp1,51.738528,5.333504,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.pomp2,'s-Hertogenbosch Sluis Empel pomp2,'s-Hertogenbosch Sluis Empel pomp2,51.738531,5.333504,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.pomp3,'s-Hertogenbosch Sluis Empel pomp3,'s-Hertogenbosch Sluis Empel pomp3,51.738533,5.333504,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.schutten,'s-Hertogenbosch Sluis Empel schutten,'s-Hertogenbosch Sluis Empel schutten,51.738522,5.333967,,,Netherlands,Rijkswaterstaat WaterWebservices
+shertogenbosch.sluisempel.uitlaat,'s-Hertogenbosch Sluis Empel uitlaat,'s-Hertogenbosch Sluis Empel uitlaat,51.740075,5.332881,,,Netherlands,Rijkswaterstaat WaterWebservices
+simonshaven,Simonshaven,Simonshaven,51.810097,4.307896,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintandries.maas,"Sint Andries, Maas","Sint Andries, Maas",51.79681,5.358789,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintandries.waal,"Sint Andries, Waal","Sint Andries, Waal",51.798608,5.357049,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintandries.waalbeneden,"Sint Andries, Waal beneden","Sint Andries, Waal beneden",51.820778,5.32266,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintandries.waalboven,"Sint Andries, Waal boven","Sint Andries, Waal boven",51.809396,5.370366,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintannaland.badstrand,"Sint Annaland, Badstrand","Sint Annaland, Badstrand",51.606822,4.104683,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintannaland.havensteiger,"Sint Annaland, Haven Steiger","Sint Annaland, Haven Steiger",51.603596,4.109586,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintannaland.oosterschelde,Sint Annaland haven,Sint Annaland haven,51.6036,4.1096,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintmaartensdijk.muiepolder.badstrand,"Sint Maartensdijk, Muiepolder, badstrand","Sint Maartensdijk, Muiepolder, badstrand",51.536551,4.062721,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintmaartenszee,Sint Maartenszee,Sint Maartenszee,52.793817,4.670695,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintmichielsgestel.dommel,"Sint-Michielsgestel, Dommel","Sint-Michielsgestel, Dommel",51.638431,5.348198,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintphilipsland.badstrand,"Sint Philipsland, badstrand","Sint Philipsland, badstrand",51.616741,4.170557,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintphilipsland.slaak.noord,Sint Philipsland Slaak noord,OB1,51.65423,4.15386,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintphilipsland.slaak.oost,Sint Philipsland Slaak oost,OM3,51.6442,4.17166,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintphilipsland.slaak.zuid,Sint Philipsland Slaak zuid,OM2,51.65136,4.15109,,,Netherlands,Rijkswaterstaat WaterWebservices
+sintpietersberg,Sint-Pietersberg,Sint-Pietersberg,50.818153,5.699367,,,Netherlands,Rijkswaterstaat WaterWebservices
+slaakdambrug,Slaakdambrug,Slaakdambrug,51.612474,4.192619,,,Netherlands,Rijkswaterstaat WaterWebservices
+slenkzuid,Slenk zuid,Slenk zuid,53.321797,5.259367,,,Netherlands,Rijkswaterstaat WaterWebservices
+sliedrecht,Sliedrecht,Sliedrecht,51.816118,4.784182,,,Netherlands,Rijkswaterstaat WaterWebservices
+slijkgat.boeisg14,"Slijkgat, boei SG14","Slijkgat, boei SG14",51.85406,3.987501,,,Netherlands,Rijkswaterstaat WaterWebservices
+slijkgat.boeisg18,"Slijkgat, boei SG18","Slijkgat, boei SG18",51.865869,3.993148,,,Netherlands,Rijkswaterstaat WaterWebservices
+slikkenvanflakkee,Slikken van Flakkee,Slikken van Flakkee,51.751905,4.018143,,,Netherlands,Rijkswaterstaat WaterWebservices
+slikkerveer,Slikkerveer,kilometer 990.5,51.892348,4.602728,,,Netherlands,Rijkswaterstaat WaterWebservices
+slobbeland.volendam,"Slobbeland, Volendam","Slobbeland, Volendam",52.491908,5.0721,,,Netherlands,Rijkswaterstaat WaterWebservices
+slochtersluis.boven,Slochtersluis,Slochtersluis,53.23631,6.65056,,,Netherlands,Rijkswaterstaat WaterWebservices
+sluis,Sluis,Sluis,51.309178,3.382084,,,Netherlands,Rijkswaterstaat WaterWebservices
+sluis15.zuidwillemsvaart,"Sluis 15, Zuid-Willemsvaart","Sluis 15, Zuid-Willemsvaart",51.272842,5.749753,,,Netherlands,Rijkswaterstaat WaterWebservices
+sluis4.schuiflinks,Sluis4 schuif links,Sluis4 schuif links,51.6085516,5.53156253,,,Netherlands,Rijkswaterstaat WaterWebservices
+sluis4.schuifrechts,Sluis4 schuif rechts,Sluis4 schuif rechts,51.60855161,5.53156253,,,Netherlands,Rijkswaterstaat WaterWebservices
+sluishelmond.boven,"Sluis Helmond, boven","Sluis Helmond, boven",51.4653,5.693592,,,Netherlands,Rijkswaterstaat WaterWebservices
+sluishintham,Sluis Hintham,Sluis Hintham,51.700275,5.358097,,,Netherlands,Rijkswaterstaat WaterWebservices
+smeermaas.zuidwillemsvaart,"Smeermaas, Zuid-Willemsvaart","Smeermaas, Zuid-Willemsvaart",50.874748,5.678438,,,Netherlands,Rijkswaterstaat WaterWebservices
+smeriggat,Smeriggat,Smeriggat,53.430735,6.021912,,,Netherlands,Rijkswaterstaat WaterWebservices
+soelekerkepolder.oost,"Soelekerkepolder, oost","Soelekerkepolder, oost",51.542206,3.730818,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis11.beneden,"Someren, sluis 11, beneden","Someren, sluis 11, beneden",51.39615,5.7264,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis11.boven,"Someren, sluis 11, boven","Someren, sluis 11, boven",51.3953,5.7277,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis12.beneden,"Someren, sluis 12, beneden","Someren, sluis 12, beneden",51.3507,5.74324,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis12.boven,"Someren, sluis 12, boven","Someren, sluis 12, boven",51.34945,5.74345,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis13,"Someren, sluis 13",ADM,51.3302,5.7467,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis13.beneden,"Someren, sluis 13, beneden","Someren, sluis 13, beneden",51.3309,5.7466,,,Netherlands,Rijkswaterstaat WaterWebservices
+someren.sluis13.boven,"Someren, sluis 13, boven","Someren, sluis 13, boven",51.3296,5.7468,,,Netherlands,Rijkswaterstaat WaterWebservices
+sonenbreugel,Son en Breugel,Son en Breugel,51.505039,5.472281,,,Netherlands,Rijkswaterstaat WaterWebservices
+sonenbreugel.beeksewaterloop,Son en Breugel inlaat Beekse Waterloop,Son en Breugel inlaat Beekse Waterloop,51.51377,5.55148,,,Netherlands,Rijkswaterstaat WaterWebservices
+sonenbreugel.wilhelminakanaal,Son en Breugel inlaat Wilhelminakanaal,Son en Breugel inlaat Wilhelminakanaal,51.50504,5.47228,,,Netherlands,Rijkswaterstaat WaterWebservices
+spaanjerd,Spaanjerd,Spaanjerd,51.129778,5.823639,,,Netherlands,Rijkswaterstaat WaterWebservices
+spaarndam.zijkanaalc,"Spaarndam, Zijkanaal C","Spaarndam, Zijkanaal C",52.420077,4.693508,,,Netherlands,Rijkswaterstaat WaterWebservices
+spakenburg,Spakenburg,Spakenburg,52.26069,5.388669,,,Netherlands,Rijkswaterstaat WaterWebservices
+spakenburg.recreatieparktkleinezeetje,"Spakenburg, Recreatiepark 't Kleine Zeetje","Spakenburg, Recreatiepark 't Kleine Zeetje",52.260105,5.375501,,,Netherlands,Rijkswaterstaat WaterWebservices
+spijkenisse.beerenplaat,"Spijkenisse, Beerenplaat",linker oever km 996.1,51.839573,4.420907,,,Netherlands,Rijkswaterstaat WaterWebservices
+spijkenisse.oudemaas,"Spijkenisse, Oude Maas",inlaat voedingskanaal,51.861661,4.333954,,,Netherlands,Rijkswaterstaat WaterWebservices
+spijkenisse.oudemaas.brug,"Spijkenisse, Oude Maas, Brug","voorheen Spijkenissebrug westelijke doorvaart, km1002.6",51.859612,4.33986,,,Netherlands,Rijkswaterstaat WaterWebservices
+spruit,Spruit,Spruit,53.511134,6.439312,,,Netherlands,Rijkswaterstaat WaterWebservices
+spuigoudswaard,Spui Goudswaard,Spui Goudswaard,51.803243,4.27938,,,Netherlands,Rijkswaterstaat WaterWebservices
+stadaantharingvliet.drinkwaterinnnamepunt,"Stad aan het Haringvliet, drinkwaterinnnamepunt","Stad aan het Haringvliet, drinkwaterinnnamepunt",51.752834,4.223002,,,Netherlands,Rijkswaterstaat WaterWebservices
+stadaantharingvliet.strand,"Stad aan het Haringvliet, strand","Stad aan het Haringvliet, strand",51.744927,4.241611,,,Netherlands,Rijkswaterstaat WaterWebservices
+stampersplaat.noord,"Stampersplaat, noord","Stampersplaat, noord",51.753087,3.944539,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavenisse,Stavenisse,Stavenisse,51.598,4.004,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavenisse.badstrand,"Stavenisse, badstrand","Stavenisse, badstrand",51.593832,4.003615,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavenisse.keeten,"Stavenisse, keeten","Stavenisse, keeten",51.60037,4.015242,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavoren.gemaalhoogland.buiten,Stavoren gemaal Hoogland buiten,Stavoren gemaal Hoogland buiten,52.87793,5.36396,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavoren.ijsselmeer,Stavoren IJsselmeer,Stavoren IJsselmeer,52.853469,5.32634,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavoren.itsuderstrand,"Stavoren, It Suderstrand","Stavoren, It Suderstrand",52.872139,5.370067,,,Netherlands,Rijkswaterstaat WaterWebservices
+stavoren.johanfrisokanaal,Stavoren JohanFrisokanaal gemaal Hoogland inlaat,Stavoren JohanFrisokanaal gemaal Hoogland inlaat,52.87805,5.364415,,,Netherlands,Rijkswaterstaat WaterWebservices
+steenbergen.roosendaalsevliet,"Steenbergen, Roosendaalsevliet","Steenbergen, Roosendaalsevliet",51.641197,4.242284,,,Netherlands,Rijkswaterstaat WaterWebservices
+steenbergsesas,Steenbergse Sas,Steenbergse Sas,51.626668,4.254928,,,Netherlands,Rijkswaterstaat WaterWebservices
+steilebank,Steile Bank,Steile Bank,52.828102,5.629536,,,Netherlands,Rijkswaterstaat WaterWebservices
+stellendam.binnen,"Stellendam, binnen","Stellendam, binnen",51.826694,4.050028,,,Netherlands,Rijkswaterstaat WaterWebservices
+stellendam.buiten,"Stellendam, buiten",meetboei,51.8317,4.042533,,,Netherlands,Rijkswaterstaat WaterWebservices
+stellendam.buitenhaven,"Stellendam, buitenhaven","Stellendam, buitenhaven",51.827028,4.033445,,,Netherlands,Rijkswaterstaat WaterWebservices
+stellendam.recreatieterreinrws,"Stellendam, recreatieterrein RWS","Stellendam, recreatieterrein RWS",51.823716,4.044816,,,Netherlands,Rijkswaterstaat WaterWebservices
+stellendam.zuiderdiep,"Stellendam, Zuiderdiep","Stellendam, Zuiderdiep",51.804103,4.056826,,,Netherlands,Rijkswaterstaat WaterWebservices
+stevensweert,Stevensweert,Stevensweert,51.131088,5.841665,,,Netherlands,Rijkswaterstaat WaterWebservices
+stevensweert.brandt.huiskensplas,"Stevensweert, Brandt, Huiskensplas",dagstrand,51.138721,5.859473,,,Netherlands,Rijkswaterstaat WaterWebservices
+stevensweert.eiland.dekis,"Stevensweert, Eiland, De Kis",dagstrand,51.137182,5.857728,,,Netherlands,Rijkswaterstaat WaterWebservices
+steyl,Steyl,Steyl,51.33689,6.117204,,,Netherlands,Rijkswaterstaat WaterWebservices
+stortemelk,Stortemelk,Stortemelk,53.338992,5.055312,,,Netherlands,Rijkswaterstaat WaterWebservices
+strandeilandvanmaurik,Strand Eiland van Maurik,Strand Eiland van Maurik,51.975226,5.421463,,,Netherlands,Rijkswaterstaat WaterWebservices
+strandnieuwkamperhoek,Strand Nieuw kamperhoek,Strand Nieuw kamperhoek,52.601666,5.647846,,,Netherlands,Rijkswaterstaat WaterWebservices
+strandnulde,Strand Nulde,Strand Nulde,52.271904,5.548364,,,Netherlands,Rijkswaterstaat WaterWebservices
+strandrcn,Strand RCN,Strand RCN,52.309816,5.546889,,,Netherlands,Rijkswaterstaat WaterWebservices
+strandschardam,Strand Schardam,Strand Schardam,52.593706,5.021697,,,Netherlands,Rijkswaterstaat WaterWebservices
+strandstaversekade,Strand Staversekade,Strand Staversekade,52.659846,5.594348,,,Netherlands,Rijkswaterstaat WaterWebservices
+streefkerk,Streefkerk,Streefkerk,51.907628,4.751275,,,Netherlands,Rijkswaterstaat WaterWebservices
+streefkerk.lek,"Streefkerk, Lek","Streefkerk, Lek",51.9047846,4.7393118,,,Netherlands,Rijkswaterstaat WaterWebservices
+surfstrandalmere,Surfstrand Almere,Surfstrand Almere,52.335004,5.205274,,,Netherlands,Rijkswaterstaat WaterWebservices
+suurhofbrug,Suurhofbrug,Suurhofbrug,51.938523,4.08346,,,Netherlands,Rijkswaterstaat WaterWebservices
+suurhofbrug.noordzijde,"Suurhofbrug, noordzijde","Suurhofbrug, noordzijde",51.937687,4.107234,,,Netherlands,Rijkswaterstaat WaterWebservices
+swifterbant.ketelmeer,"Swifterbant, Ketelmeer","voorheen Ketelmeer, west",52.6055,5.6455,,,Netherlands,Rijkswaterstaat WaterWebservices
+swifterweg,Swifterweg,Hoge Vaart,52.460358,5.693242,,,Netherlands,Rijkswaterstaat WaterWebservices
+tennesseehaven,Tennesseehaven,Tennesseehaven,51.963507,4.093561,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.10kmuitdekust,"Ter Heijde, 10 km uit de kust","Ter Heijde, 10 km uit de kust",52.109016,4.087249,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.1kmuitdekust,"Ter Heijde, 1 km uit de kust","Ter Heijde, 1 km uit de kust",52.045696,4.168627,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.20kmuitdekust,"Ter Heijde, 20 km uit de kust","Ter Heijde, 20 km uit de kust",52.182537,3.992029,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.2kmuitdekust,"Ter Heijde, 2 km uit de kust","Ter Heijde, 2 km uit de kust",52.052354,4.159742,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.30kmuitdekust,"Ter Heijde, 30 km uit de kust","Ter Heijde, 30 km uit de kust",52.253171,3.899781,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.4kmuitdekust,"Ter Heijde, 4 km uit de kust","Ter Heijde, 4 km uit de kust",52.066247,4.141421,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.50kmuitdekust,"Ter Heijde, 50 km uit de kust","Ter Heijde, 50 km uit de kust",52.344824,3.643155,,,Netherlands,Rijkswaterstaat WaterWebservices
+terheijde.70kmuitdekust,"Ter Heijde, 70 km uit de kust","Ter Heijde, 70 km uit de kust",52.433981,3.389857,,,Netherlands,Rijkswaterstaat WaterWebservices
+terherne.beneden,Terherne beneden,Terherne beneden,53.04323,5.76625,,,Netherlands,Rijkswaterstaat WaterWebservices
+terherne.boven,Terherne boven,Terherne boven,53.04488,5.7706,,,Netherlands,Rijkswaterstaat WaterWebservices
+termunten.zeestrand,"Termunten, zeestrand","Termunten, zeestrand",53.302878,7.031538,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen,Terneuzen,Terneuzen,51.336212,3.819812,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.boei20,"Terneuzen, boei 20","Terneuzen, boei 20",51.346537,3.825487,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.goesekade,"Terneuzen, Goese Kade","Terneuzen, Goese Kade",51.319879,3.82195,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.landtong,"Terneuzen, landtong","Terneuzen, landtong",51.322031,3.824889,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.sluiskilbrug,"Terneuzen, Sluiskilbrug","Terneuzen, Sluiskilbrug",51.294,3.8354,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.westsluis.buiten,"Terneuzen, westsluis, buiten","Terneuzen, westsluis, buiten",51.337472,3.812564,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.westsluis.kanaalzijde,"Terneuzen, westsluis, kanaalzijde","Terneuzen, westsluis, kanaalzijde",51.324309,3.819115,,,Netherlands,Rijkswaterstaat WaterWebservices
+terneuzen.westsluisinloop,"Terneuzen, westsluis inloop","Terneuzen, westsluis inloop",51.326006,3.818972,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.100kmuitdekust,"Terschelling, 100 km uit de kust","Terschelling, 100 km uit de kust",54.148726,4.34059,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.10kmuitdekust,"Terschelling, 10 km uit de kust","Terschelling, 10 km uit de kust",53.460377,5.09952,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.135kmuitdekust,"Terschelling, 135 km uit de kust","Terschelling, 135 km uit de kust",54.414843,4.03974,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.175kmuitdekust,"Terschelling, 175 km uit de kust","Terschelling, 175 km uit de kust",54.718461,3.690277,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.20kmuitdekust,"Terschelling, 20 km uit de kust","Terschelling, 20 km uit de kust",53.536359,5.02044,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.235kmuitdekust,"Terschelling, 235 km uit de kust","Terschelling, 235 km uit de kust",55.171526,3.156081,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.30kmuitdekust,"Terschelling, 30 km uit de kust","Terschelling, 30 km uit de kust",53.612733,4.939633,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.40kmuitdekust,"Terschelling, 40 km uit de kust","Terschelling, 40 km uit de kust",53.689154,4.853131,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.4kmuitdekust,"Terschelling, 4 km uit de kust","Terschelling, 4 km uit de kust",53.414543,5.149245,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.50kmuitdekust,"Terschelling, 50 km uit de kust","Terschelling, 50 km uit de kust",53.766773,4.765613,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.60kmuitdekust,"Terschelling, 60 km uit de kust","Terschelling, 60 km uit de kust",53.843327,4.687311,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.70kmuitdekust,"Terschelling, 70 km uit de kust","Terschelling, 70 km uit de kust",53.921038,4.608012,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.badstrandwestaanzee,"Terschelling, Badstrand West aan Zee","Terschelling, Badstrand West aan Zee",53.405252,5.251798,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.noordzee,"Terschelling, Noordzee","Terschelling, Noordzee",53.442486,5.333033,,,Netherlands,Rijkswaterstaat WaterWebservices
+terschelling.west,"Terschelling, west","Terschelling, west",53.363045,5.220026,,,Netherlands,Rijkswaterstaat WaterWebservices
+texel.noordzee,"Texel, Noordzee","Texel, Noordzee",53.120612,4.733193,,,Netherlands,Rijkswaterstaat WaterWebservices
+texel.oudeschild,"Texel, Oudeschild","Texel, Oudeschild",53.038835,4.850192,,,Netherlands,Rijkswaterstaat WaterWebservices
+texel.westgat,"Texel, Westgat","Texel, Westgat",52.940591,4.644484,,,Netherlands,Rijkswaterstaat WaterWebservices
+texelstroom,Texelstroom,Texelstroom,53.019577,4.824649,,,Netherlands,Rijkswaterstaat WaterWebservices
+tholen.bergsediepsluis.buiten,"Tholen, Bergse Diepsluis, buiten",west,51.511335,4.165743,,,Netherlands,Rijkswaterstaat WaterWebservices
+tholen.nieuwehaven.boeinh7,"Tholen, Nieuwe Haven, boei NH7","Tholen, Nieuwe Haven, boei NH7",51.512748,4.215928,,,Netherlands,Rijkswaterstaat WaterWebservices
+thorn.degrotehegge,"Thorn, De Grote Hegge",dagstrand,51.155656,5.843738,,,Netherlands,Rijkswaterstaat WaterWebservices
+tiel.haven,"Tiel, haven","Tiel, haven",51.887763,5.441528,,,Netherlands,Rijkswaterstaat WaterWebservices
+tiel.sluis.kanaal,"Tiel Sluis, kanaal","Tiel Sluis, kanaal",51.904386,5.452592,,,Netherlands,Rijkswaterstaat WaterWebservices
+tiel.sluis.waal,"Tiel Sluis, Waal","Tiel Sluis, Waal",51.899,5.456,,,Netherlands,Rijkswaterstaat WaterWebservices
+tiel.waal,"Tiel, Waal","Tiel, Waal",51.882384,5.440687,,,Netherlands,Rijkswaterstaat WaterWebservices
+tiengemeten,Tiengemeten,Tiengemeten,51.735822,4.354986,,,Netherlands,Rijkswaterstaat WaterWebservices
+tilburg.sluis2.beneden,"Tilburg, sluis 2, beneden","Tilburg, sluis 2, beneden",51.59716,4.9908,,,Netherlands,Rijkswaterstaat WaterWebservices
+tilburg.sluis2.boven,"Tilburg, sluis 2, boven","Tilburg, sluis 2, boven",51.59645,4.9924,,,Netherlands,Rijkswaterstaat WaterWebservices
+tilburg.sluis3,Tilburg Sluis 3,Tilburg Sluis 3,51.58214439,5.03554064,,,Netherlands,Rijkswaterstaat WaterWebservices
+tilburg.sluis3.beneden,"Tilburg, sluis 3, beneden","Tilburg, sluis 3, beneden",51.582,5.0324,,,Netherlands,Rijkswaterstaat WaterWebservices
+tilburg.sluis3.boven,"Tilburg, sluis 3, boven","Tilburg, sluis 3, boven",51.5816,5.036,,,Netherlands,Rijkswaterstaat WaterWebservices
+tilburg.sluis3.kolk,Tilburg Sluis 3 kolk,Tilburg Sluis 3 kolk,51.58214439,5.03554064,,,Netherlands,Rijkswaterstaat WaterWebservices
+tullentwaal.oost,"Tull en 't Waal, oost","Tull en 't Waal, oost",51.994208,5.140409,,,Netherlands,Rijkswaterstaat WaterWebservices
+tullentwaal.west,"Tull en 't Waal, west","Tull en 't Waal, west",51.997563,5.133401,,,Netherlands,Rijkswaterstaat WaterWebservices
+uikhoven,Uikhoven,Uikhoven,50.925556,5.727583,,,Netherlands,Rijkswaterstaat WaterWebservices
+uitdam,Uitdam,Uitdam,52.420992,5.117749,,,Netherlands,Rijkswaterstaat WaterWebservices
+uitdam.strand,"Uitdam, strand","Uitdam, strand",52.424191,5.07342,,,Netherlands,Rijkswaterstaat WaterWebservices
+uithuizerwad,Uithuizerwad,"voorheen Uithuizerwad, 1",53.466778,6.749939,,,Netherlands,Rijkswaterstaat WaterWebservices
+urk,Urk,Urk,52.65882,5.599885,,,Netherlands,Rijkswaterstaat WaterWebservices
+urk.dijkstrand,"Urk, dijkstrand","Urk, dijkstrand",52.663389,5.59259,,,Netherlands,Rijkswaterstaat WaterWebservices
+urk.ijsselmeer.oost.meetpaal2,"Urk, IJsselmeer, oost, meetpaal 02","Urk, IJsselmeer, oost, meetpaal 02",52.748351,5.559,,,Netherlands,Rijkswaterstaat WaterWebservices
+urk.ijsselmeer.zuid.meetpaal46,"Urk, IJsselmeer, zuid, meetpaal 46","Urk, IJsselmeer, zuid, meetpaal 46",52.71,5.4929,,,Netherlands,Rijkswaterstaat WaterWebservices
+urmond,Urmond,monding van de Ur,50.99143,5.768904,,,Netherlands,Rijkswaterstaat WaterWebservices
+vaarwaterlangshoofdplaat,Vaarwater langs Hoofdplaat,Vaarwater langs Hoofdplaat,51.377457,3.672677,,,Netherlands,Rijkswaterstaat WaterWebservices
+valkenburg,Valkenburg,Valkenburg,52.168377,4.403757,,,Netherlands,Rijkswaterstaat WaterWebservices
+valkenisse.boei65,"Valkenisse, boei 65","Valkenisse, boei 65",51.370508,4.114792,,,Netherlands,Rijkswaterstaat WaterWebservices
+vechterweerd.boven,"Vechterweerd, boven","Vechterweerd, boven",52.517531,6.21315,,,Netherlands,Rijkswaterstaat WaterWebservices
+veen,Veen,Afgedamde Maas,51.780042,5.111874,,,Netherlands,Rijkswaterstaat WaterWebservices
+veere,Veere,Veere,51.542099,3.667385,,,Netherlands,Rijkswaterstaat WaterWebservices
+veere.havenmond,"Veere, havenmond","Veere, havenmond",51.548295,3.673062,,,Netherlands,Rijkswaterstaat WaterWebservices
+veere.schutsluis,"Veere, schutsluis","Veere, schutsluis",51.540751,3.667436,,,Netherlands,Rijkswaterstaat WaterWebservices
+veersegat.dam,"Veersegat, dam","Veersegat, dam",51.575778,3.634799,,,Netherlands,Rijkswaterstaat WaterWebservices
+veersegat.dam.meerzijde.badstrand,"Veersegat, Dam, meerzijde, badstrand","Veersegat, Dam, meerzijde, badstrand",51.583228,3.628017,,,Netherlands,Rijkswaterstaat WaterWebservices
+veersemeer.deelgebied,"Veerse Meer, deelgebied","Veerse Meer, deelgebied",51.532006,3.715334,,,Netherlands,Rijkswaterstaat WaterWebservices
+veessen,Veessen Wapenveld,Veessen Wapenveld,52.368033,6.077656,,,Netherlands,Rijkswaterstaat WaterWebservices
+veessen.beneden,"Veessen, beneden","Veessen, beneden",52.36814,6.076946,,,Netherlands,Rijkswaterstaat WaterWebservices
+veessen.boven,"Veessen, boven","Veessen, boven",52.360674,6.091584,,,Netherlands,Rijkswaterstaat WaterWebservices
+veghel.sluis4.beneden,"Veghel, sluis 4, beneden","Veghel, sluis 4, beneden",51.60915,5.5306,,,Netherlands,Rijkswaterstaat WaterWebservices
+veghel.sluis4.boven,"Veghel, sluis 4, boven","Veghel, sluis 4, boven",51.60825,5.5323,,,Netherlands,Rijkswaterstaat WaterWebservices
+veghel.sluis4.inlaat,"Veghel, Sluis 4, inlaat",Spuien,51.608558,5.531564,,,Netherlands,Rijkswaterstaat WaterWebservices
+veghel.sluis4.uitlaat,"Veghel, Sluis 4, uitlaat",NettobalansUIT,51.608553,5.531564,,,Netherlands,Rijkswaterstaat WaterWebservices
+velden,Velden,Velden,51.418594,6.157395,,,Netherlands,Rijkswaterstaat WaterWebservices
+velp,Velp,Velp,51.99176,6.005978,,,Netherlands,Rijkswaterstaat WaterWebservices
+velsen.velserkom,Velserkom,Velserkom,52.467611,4.623665,,,Netherlands,Rijkswaterstaat WaterWebservices
+velsenzuid.spaarndammerpolder,"Velsen-Zuid, Spaarndammerpolder","Velsen-Zuid, Spaarndammerpolder",52.441489,4.69707,,,Netherlands,Rijkswaterstaat WaterWebservices
+veluwemeer.midden,"Veluwemeer, midden",zwaartepunt Veluwemeer,52.400648,5.677842,,,Netherlands,Rijkswaterstaat WaterWebservices
+venlo,Venlo,Venlo,51.36575,6.15722,,,Netherlands,Rijkswaterstaat WaterWebservices
+verdieptelosplaats,Verdiepte losplaats,Verdiepte losplaats,52.051178,4.007419,,,Netherlands,Rijkswaterstaat WaterWebservices
+verdieptelosplaats.noordoost,"Verdiepte losplaats, noord-oost","Verdiepte losplaats, noord-oost",52.062858,4.0209,,,Netherlands,Rijkswaterstaat WaterWebservices
+verdieptelosplaats.zuidwest,"Verdiepte losplaats, zuid-west","Verdiepte losplaats, zuid-west",52.042806,3.998147,,,Netherlands,Rijkswaterstaat WaterWebservices
+vianen,Vianen,Vianen,51.995281,5.098542,,,Netherlands,Rijkswaterstaat WaterWebservices
+vierlingsbeek,Vierlingsbeek,Vierlingsbeek,51.596835,6.024535,,,Netherlands,Rijkswaterstaat WaterWebservices
+vilsteren.beneden,"Vilsteren, beneden","Vilsteren, beneden",52.521566,6.334601,,,Netherlands,Rijkswaterstaat WaterWebservices
+vilsteren.boven,"Vilsteren, boven","Vilsteren, boven",52.521324,6.336806,,,Netherlands,Rijkswaterstaat WaterWebservices
+vingegatii,Vingegat II,Vingegat II,53.292515,5.505364,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlaardingen,Vlaardingen,Vlaardingen,51.899639,4.349048,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlaktevanderaan,Vlakte van de Raan,Vlakte van de Raan,51.503721,3.242164,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlieland.badstrandtbadhuis,"Vlieland, Badstrand 't Badhuis","Vlieland, Badstrand 't Badhuis",53.304982,5.051838,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlieland.haven,"Vlieland, haven","Vlieland, haven",53.296127,5.091456,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlieland.jachthaven,"Vlieland, jachthaven","Vlieland, jachthaven",53.296034,5.089957,,,Netherlands,Rijkswaterstaat WaterWebservices
+vliestroom,Vliestroom,Vliestroom,53.313348,5.159904,,,Netherlands,Rijkswaterstaat WaterWebservices
+vliestroom.zuid,"Vliestroom, zuid","Vliestroom, zuid",53.262154,5.172012,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlietepolder,Vlietepolder,Vlietepolder,51.59932,3.75183,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlissingen,Vlissingen,Vlissingen,51.442,3.6,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlissingen.boeissvh,"Vlissingen, boei SSVH","Vlissingen, boei SSVH",51.411991,3.565619,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlissingen.keersluisbrug,"Vlissingen, keersluisbrug","Vlissingen, keersluisbrug",51.449528,3.585989,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlissingen.nollebadstrand,"Vlissingen, Nolle badstrand","Vlissingen, Nolle badstrand",51.450223,3.549845,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlissingen.roeiershoofd,"Vlissingen, Roeiershoofd","Vlissingen, Roeiershoofd",51.441353,3.574803,,,Netherlands,Rijkswaterstaat WaterWebservices
+vlodrop,Vlodrop,Roer,51.133844,6.082115,,,Netherlands,Rijkswaterstaat WaterWebservices
+volkerak.meetplaats2,"Volkerak, meetplaats 02","Volkerak, meetplaats 02",51.661054,4.357414,,,Netherlands,Rijkswaterstaat WaterWebservices
+vooroeverandijkkoopmanspolder,Vooroever Andijk Koopmanspolder,Vooroever Andijk Koopmanspolder,52.74069,5.178394,,,Netherlands,Rijkswaterstaat WaterWebservices
+vossemeerdijkkm0p3,Vossemeerdijk km 0.3,Vossemeerdijk km 0.3,52.547011,5.854166,,,Netherlands,Rijkswaterstaat WaterWebservices
+vossenbeemd,Vossenbeemd,Vossenbeemd,51.469062,5.691819,,,Netherlands,Rijkswaterstaat WaterWebservices
+vreeswijk,Vreeswijk,Vreeswijk,52.009863,5.107405,,,Netherlands,Rijkswaterstaat WaterWebservices
+vrijheidsplaat,Vrijheidsplaat,Vrijheidsplaat,53.410824,5.667268,,,Netherlands,Rijkswaterstaat WaterWebservices
+vrouwenpolder,Vrouwenpolder,Vrouwenpolder,51.564896,3.640556,,,Netherlands,Rijkswaterstaat WaterWebservices
+vrouwenpolder.breezand.badstrand,"Vrouwenpolder, Breezand, badstrand","Vrouwenpolder, Breezand, badstrand",51.590031,3.620104,,,Netherlands,Rijkswaterstaat WaterWebservices
+vrouwezand,Vrouwezand,Vrouwezand,52.810348,5.393138,,,Netherlands,Rijkswaterstaat WaterWebservices
+vrouwezand.meetpaal,"Vrouwezand, meetpaal",Friese kust,52.810405,5.487566,,,Netherlands,Rijkswaterstaat WaterWebservices
+vuursteenweg,Vuursteenweg,Noordertocht,52.576504,5.596685,,,Netherlands,Rijkswaterstaat WaterWebservices
+vuurtorenbadstrandhellevoetsluis,Vuurtoren Badstrand Hellevoetsluis,Vuurtoren Badstrand Hellevoetsluis,51.821299,4.124278,,,Netherlands,Rijkswaterstaat WaterWebservices
+waal.linkeroever,"Waal, linkeroever","Waal, linkeroever",51.853846,5.879398,,,Netherlands,Rijkswaterstaat WaterWebservices
+waal.rechteroever,"Waal, rechteroever","Waal, rechteroever",51.855478,5.876077,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm871p200.ro,"Waal km 871.200, ro","Waal km 871.200, ro",51.876336,5.990478,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm875p800.lo,"Waal km 875.800, lo","Waal km 875.800, lo",51.859891,5.946818,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm880p100.ro,"Waal km 880.100, ro","Waal km 880.100, ro",51.873998,5.902519,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm881p900.ro,"Waal km 881.900, ro","Waal km 881.900, ro",51.862714,5.880366,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm883p000.ro,"Waal km 883.000, ro","Waal km 883.000, ro",51.854912,5.873966,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm889p400.lo,"Waal km 889.400, lo","Waal km 889.400, lo",51.874912,5.795983,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm889p400.ro,"Waal km 889.400, ro","Waal km 889.400, ro",51.877135,5.797746,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm889p600.ro,"Waal km 889.600, ro","Waal km 889.600, ro",51.877538,5.795397,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm889p700.lo,"Waal km 889.700, lo","Waal km 889.700, lo",51.875247,5.792734,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm890p000.ro,"Waal km 890.000, ro","Waal km 890.000, ro",51.878746,5.789207,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm893p200.ro,"Waal km 893.200, ro","Waal km 893.200, ro",51.885892,5.744853,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm893p400.lo,"Waal km 893.400, lo","Waal km 893.400, lo",51.883856,5.74048,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm893p400.ro,"Waal km 893.400, ro","Waal km 893.400, ro",51.886132,5.742792,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm897p800.lo,"Waal km 897.800, lo","Waal km 897.800, lo",51.894408,5.681957,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm897p800.ro,"Waal km 897.800, ro","Waal km 897.800, ro",51.896809,5.681493,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm898p000.lo,"Waal km 898.000, lo","Waal km 898.000, lo",51.894308,5.678484,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm898p000.ro,"Waal km 898.000, ro","Waal km 898.000, ro",51.896771,5.678645,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm901p800.lo,"Waal km 901.800, lo","Waal km 901.800, lo",51.898162,5.623735,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm901p800.ro,"Waal km 901.800, ro","Waal km 901.800, ro",51.90074,5.624329,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm902p000.lo,"Waal km 902.000, lo","Waal km 902.000, lo",51.898167,5.621192,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm905p100.ro,"Waal km 905.100, ro","Waal km 905.100, ro",51.903561,5.576902,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm905p400.lo,"Waal km 905.400, lo","Waal km 905.400, lo",51.900546,5.572021,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm905p400.ro,"Waal km 905.400, ro","Waal km 905.400, ro",51.903018,5.572075,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm905p600.ro,"Waal km 905.600, ro","Waal km 905.600, ro",51.903104,5.568893,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm909p000.lo,"Waal km 909.000, lo","Waal km 909.000, lo",51.891237,5.524132,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm909p000.ro,"Waal km 909.000, ro","Waal km 909.000, ro",51.893513,5.522831,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm909p100.lo,"Waal km 909.100, lo","Waal km 909.100, lo",51.890673,5.521966,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm909p200.ro,"Waal km 909.200, ro","Waal km 909.200, ro",51.893716,5.518444,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm917p000.ro,"Waal km 917.000, ro","Waal km 917.000, ro",51.868842,5.421193,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm922p000.ro,"Waal km 922.000, ro","Waal km 922.000, ro",51.831306,5.386518,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm925p700.ro,"Waal km 925.700, ro","Waal km 925.700, ro",51.801816,5.356098,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm929p800.lo,"Waal km 929.800, lo","Waal km 929.800, lo",51.821079,5.310891,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm937p500.lo,"Waal km 937.500, lo","Waal km 937.500, lo",51.808645,5.205095,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm937p500.ro,"Waal km 937.500, ro","Waal km 937.500, ro",51.811388,5.205577,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm937p600.lo,"Waal km 937.600, lo","Waal km 937.600, lo",51.808885,5.202754,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm937p800.ro,"Waal km 937.800, ro","Waal km 937.800, ro",51.811671,5.202864,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm939p900.ro,"Waal km 939.900, ro","Waal km 939.900, ro",51.818666,5.175488,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm946p000.ro,"Waal km 946.000, ro","Waal km 946.000, ro",51.828617,5.094832,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalkm993p200.lo,"Waal km 993.200, lo","Waal km 993.200, lo",51.883533,5.743091,,,Netherlands,Rijkswaterstaat WaterWebservices
+waalwijk,Waalwijk,Waalwijk,51.71243,5.07488,,,Netherlands,Rijkswaterstaat WaterWebservices
+waarde,Waarde,Waarde,51.413252,4.06616,,,Netherlands,Rijkswaterstaat WaterWebservices
+waddenzee.ra,"Waddenzee, Ra","Waddenzee, Ra",53.479134,6.663717,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.10kmuitdekust,"Walcheren, 10 km uit de kust","Walcheren, 10 km uit de kust",51.596303,3.326519,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.1kmuitdekust,"Walcheren, 1 km uit de kust","Walcheren, 1 km uit de kust",51.560753,3.421511,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.20kmuitdekust,"Walcheren, 20 km uit de kust","Walcheren, 20 km uit de kust",51.657798,3.219245,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.2kmuitdekust,"Walcheren, 2 km uit de kust","Walcheren, 2 km uit de kust",51.548074,3.409531,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.30kmuitdekust,"Walcheren, 30 km uit de kust","Walcheren, 30 km uit de kust",51.717521,3.112297,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.4kmuitdekust,"Walcheren, 4 km uit de kust","Walcheren, 4 km uit de kust",51.560752,3.391791,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.50kmuitdekust,"Walcheren, 50 km uit de kust","Walcheren, 50 km uit de kust",51.839189,2.895343,,,Netherlands,Rijkswaterstaat WaterWebservices
+walcheren.70kmuitdekust,"Walcheren, 70 km uit de kust","Walcheren, 70 km uit de kust",51.956135,2.677835,,,Netherlands,Rijkswaterstaat WaterWebservices
+walsoorden,Walsoorden,Walsoorden,51.398427,4.026206,,,Netherlands,Rijkswaterstaat WaterWebservices
+wanssum.oudemaas,"Wanssum, Oude Maas","Wanssum, Oude Maas",51.535189,6.079147,,,Netherlands,Rijkswaterstaat WaterWebservices
+warder,Warder,Warder,52.565916,5.032915,,,Netherlands,Rijkswaterstaat WaterWebservices
+waspik,Waspik,Donge,51.682803,4.918703,,,Netherlands,Rijkswaterstaat WaterWebservices
+wassenaarseslag,Wassenaarseslag,Wassenaarseslag,52.163438,4.346716,,,Netherlands,Rijkswaterstaat WaterWebservices
+waterlandstrandhemmelandmonnickendam,Waterlandstrand Hemmeland Monnickendam,Waterlandstrand Hemmeland Monnickendam,52.455111,5.048647,,,Netherlands,Rijkswaterstaat WaterWebservices
+watersportcentrumdebijland,Watersportcentrum De Bijland,Watersportcentrum De Bijland,51.865106,6.079573,,,Netherlands,Rijkswaterstaat WaterWebservices
+waterweg.mondingnabijdezuidwal,"Waterweg, monding nabij de Zuidwal",Wa-II,51.983695,4.049158,,,Netherlands,Rijkswaterstaat WaterWebservices
+weert.lozen,"Weert, Lozen",km 50,51.223141,5.602491,,,Netherlands,Rijkswaterstaat WaterWebservices
+weert.sluis16.beneden,"Weert, sluis 16, beneden","Weert, sluis 16, beneden",51.245947,5.669381,,,Netherlands,Rijkswaterstaat WaterWebservices
+weert.sluis16.boven,"Weert, sluis 16, boven","Weert, sluis 16, boven",51.245056,5.666583,,,Netherlands,Rijkswaterstaat WaterWebservices
+weesp.amsterdamrijnkanaal,"Weesp, Amsterdam-Rijnkanaal","Weesp, Amsterdam-Rijnkanaal",52.316829,5.018799,,,Netherlands,Rijkswaterstaat WaterWebservices
+weesp.vecht,"Weesp, Vecht","Weesp, Vecht",52.309726,5.047892,,,Netherlands,Rijkswaterstaat WaterWebservices
+well,Well,dorp,51.54744,6.09245,,,Netherlands,Rijkswaterstaat WaterWebservices
+well.badstrand,"Well, badstrand","Well, badstrand",51.747529,5.185952,,,Netherlands,Rijkswaterstaat WaterWebservices
+wellerlooi,Wellerlooi,voorheen Well,51.543406,6.115187,,,Netherlands,Rijkswaterstaat WaterWebservices
+wellseind,Wellseind,Oude arm van de afgedamde Maas,51.748013,5.185052,,,Netherlands,Rijkswaterstaat WaterWebservices
+wemeldinge,Wemeldinge,Wemeldinge,51.496841,4.056964,,,Netherlands,Rijkswaterstaat WaterWebservices
+wemeldinge.badstrand,"Wemeldinge, badstrand","Wemeldinge, badstrand",51.521166,3.999621,,,Netherlands,Rijkswaterstaat WaterWebservices
+wemeldinge.oudesluizen,"Wemeldinge, oude sluizen","Wemeldinge, oude sluizen",51.524093,4.003855,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.binnen,"Werkendam, binnen",Steurgat,51.803884,4.876849,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.binnenkievitswaard,"Werkendam, Binnen Kievitswaard","Werkendam, Binnen Kievitswaard",51.792222,4.830278,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.happenhennip,"Werkendam, Happen Hennip","Werkendam, Happen Hennip",51.780722,4.795944,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.kleinezalm,"Werkendam, Kleine Zalm","Werkendam, Kleine Zalm",51.761722,4.821139,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.kooike,"Werkendam, Kooike","Werkendam, Kooike",51.783139,4.862972,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.middelstekievitswaard,"Werkendam, Middelste Kievitswaard","Werkendam, Middelste Kievitswaard",51.784694,4.807028,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.nieuwemerwede,"Werkendam, Nieuwe Merwede",buiten,51.806041,4.876824,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.steenenmuur,"Werkendam, Steenenmuur","Werkendam, Steenenmuur",51.765278,4.839778,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.steurgat,"Werkendam, Steurgat","Werkendam, Steurgat",51.799139,4.871389,,,Netherlands,Rijkswaterstaat WaterWebservices
+werkendam.vogelenzang,"Werkendam, Vogelenzang","Werkendam, Vogelenzang",51.769167,4.836139,,,Netherlands,Rijkswaterstaat WaterWebservices
+wessem.molengreend,"Wessem, Molengreend","Wessem, Molengreend",51.162629,5.89613,,,Netherlands,Rijkswaterstaat WaterWebservices
+wessem.recreatiestrandcomfortparcwessem,"Wessem, Recreatiestrand Comfortparc Wessem","Wessem, Recreatiestrand Comfortparc Wessem",51.153627,5.872004,,,Netherlands,Rijkswaterstaat WaterWebservices
+westereems.west,"Westereems, west","Westereems, west",53.618056,6.366667,,,Netherlands,Rijkswaterstaat WaterWebservices
+westerhoofd,Westerhoofd,Westerhoofd,53.320224,6.994933,,,Netherlands,Rijkswaterstaat WaterWebservices
+westerschouwen.rotondebadstrand,"Westerschouwen, Rotonde badstrand","Westerschouwen, Rotonde badstrand",51.669637,3.702156,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort,Westervoort,Westervoort,51.967031,5.954706,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.1,"Westervoort, 1",voorheen IJsselkop,51.9705,5.962,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.2,"Westervoort, 2",IJsseldijkerwaard,51.9705,5.962,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.brug,"Westervoort, brug","Westervoort, brug",51.96703,5.954707,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.hondbroekschepleij.ijssel,Westervoort Hondsbroeksche Pleij IJssel,Westervoort Hondsbroeksche Pleij IJssel,51.959934,5.950237,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.hondsbroekschepleij.geul,"Westervoort, Hondsbroeksche Pleij, Geul","voorheen, oost",51.956117,5.953158,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.hondsbroekschepleij.ijssel,"Westervoort, Hondsbroeksche Pleij, IJssel","voorheen, west",51.959933,5.950239,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoort.ijsselkop,Westervoort IJsselkop,Westervoort IJsselkop,51.9507,5.953,,,Netherlands,Rijkswaterstaat WaterWebservices
+westervoortpleij,Westervoort Pleij,Westervoort Pleij,51.964873,5.954825,,,Netherlands,Rijkswaterstaat WaterWebservices
+westhaven.2,"Westhaven, 2","Westhaven, 2",52.403806,4.819536,,,Netherlands,Rijkswaterstaat WaterWebservices
+westkapelle,Westkapelle,Westkapelle,51.521448,3.440031,,,Netherlands,Rijkswaterstaat WaterWebservices
+westkapelle.erikabadstrand,"Westkapelle, Erika badstrand","Westkapelle, Erika badstrand",51.52402,3.437903,,,Netherlands,Rijkswaterstaat WaterWebservices
+westkomscheurrak,Westkom - Scheurrak,Westkom - Scheurrak,53.105921,5.08703,,,Netherlands,Rijkswaterstaat WaterWebservices
+westmeep,West Meep,West Meep,53.2883,5.229012,,,Netherlands,Rijkswaterstaat WaterWebservices
+westmeep.west,"West Meep, west","West Meep, west",53.288682,5.184026,,,Netherlands,Rijkswaterstaat WaterWebservices
+westnieuwland,West Nieuwland,West Nieuwland,51.785765,3.86466,,,Netherlands,Rijkswaterstaat WaterWebservices
+westrepart.badstrand,"West Repart, badstrand","West Repart, badstrand",51.739264,3.828724,,,Netherlands,Rijkswaterstaat WaterWebservices
+westzaan,Westzaan,kilometer 13,52.427822,4.764255,,,Netherlands,Rijkswaterstaat WaterWebservices
+wevershoof.onderdijkzwemstrand,"Wevershoof, Onderdijk zwemstrand","Wevershoof, Onderdijk zwemstrand",52.758153,5.120939,,,Netherlands,Rijkswaterstaat WaterWebservices
+wielingen,Wielingen,Wielingen,51.409907,3.358291,,,Netherlands,Rijkswaterstaat WaterWebservices
+wiene,Wiene,Wiene,52.240089,6.650719,,,Netherlands,Rijkswaterstaat WaterWebservices
+wierbalg.noord,"Wierbalg, noord","Wierbalg, noord",52.977591,4.948761,,,Netherlands,Rijkswaterstaat WaterWebservices
+wieringen.ijsselmeer.oost,Wieringen IJsselmeer oost,Wieringen IJsselmeer oost,52.873472,5.118889,,,Netherlands,Rijkswaterstaat WaterWebservices
+wierumergronden,Wierumergronden,Wierumergronden,53.515827,5.958261,,,Netherlands,Rijkswaterstaat WaterWebservices
+wierumerwad,Wierumerwad,1,53.407684,6.063855,,,Netherlands,Rijkswaterstaat WaterWebservices
+wijhe,Wijhe,Wijhe,52.387,6.126917,,,Netherlands,Rijkswaterstaat WaterWebservices
+wijkaanzee,Wijk aan Zee,Wijk aan Zee,52.498482,4.584626,,,Netherlands,Rijkswaterstaat WaterWebservices
+wijkbijduurstede,Wijk bij Duurstede,Wijk bij Duurstede,51.964437,5.342533,,,Netherlands,Rijkswaterstaat WaterWebservices
+wijkbijduurstede.amsterdamrijnkanaal,"Wijk bij Duurstede, Amsterdam-Rijnkanaal","Wijk bij Duurstede, Amsterdam-Rijnkanaal",51.97479,5.293258,,,Netherlands,Rijkswaterstaat WaterWebservices
+wijkschewaard.badstrand,"Wijksche Waard, Badstrand","Wijksche Waard, Badstrand",51.773773,5.129937,,,Netherlands,Rijkswaterstaat WaterWebservices
+wilhelminabrug,Wilhelminabrug,Wilhelminabrug,51.643556,4.843404,,,Netherlands,Rijkswaterstaat WaterWebservices
+wilhelminakanaal.sluisi,"Wilhelminakanaal, sluis I","Wilhelminakanaal, sluis I",51.643808,4.839644,,,Netherlands,Rijkswaterstaat WaterWebservices
+wilhelminakanaal.sluisiii,"Wilhelminakanaal, sluis III","Wilhelminakanaal, sluis III",51.581459,5.03517,,,Netherlands,Rijkswaterstaat WaterWebservices
+wilhelminakanaal.sluisiv,"Wilhelminakanaal, sluis IV","Wilhelminakanaal, sluis IV",51.49777,5.206369,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemsdorp,Willemsdorp,Willemsdorp,51.730274,4.628849,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemstad,Willemstad,Willemstad,51.694837,4.440684,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemstad.hollandschdiep,"Willemstad, Hollandsch Diep",Volkeraksluizen spuisluis,51.696401,4.40689,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemstad.hollandschdiep.volkerakspuisluis,Willemstad Hollandschdiep Volkerakspuisluis,Willemstad Hollandschdiep Volkerakspuisluis,51.694889,4.421779,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemstad.volkerak,"Willemstad, Volkerak",voorheen Rak zuid,51.682434,4.397417,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemstad.volkeraksluizen.schuif2,Willemstad Volkeraksluizen gat2,Willemstad Volkeraksluizen gat2,51.692446,4.401538,,,Netherlands,Rijkswaterstaat WaterWebservices
+willemstad.volkeraksluizen.schuif3,Willemstad Volkeraksluizen gat3,Willemstad Volkeraksluizen gat3,51.691823,4.402275,,,Netherlands,Rijkswaterstaat WaterWebservices
+wissenkerke,Wissenkerke,Wissenkerke,51.601576,3.720566,,,Netherlands,Rijkswaterstaat WaterWebservices
+wissenkerke.boei7,"Wissenkerke, boei 7","Wissenkerke, boei 7",51.607513,3.707021,,,Netherlands,Rijkswaterstaat WaterWebservices
+wolderwijd.midden,"Wolderwijd, midden",zwaartepunt Wolderwijd,52.349817,5.567859,,,Netherlands,Rijkswaterstaat WaterWebservices
+woldstrand,Woldstrand,Woldstrand,52.327771,5.548758,,,Netherlands,Rijkswaterstaat WaterWebservices
+wolfshoek,Wolfshoek,Wolfshoek,53.246847,5.155011,,,Netherlands,Rijkswaterstaat WaterWebservices
+wolphaartsdijk,Wolphaartsdijk,Wolphaartsdijk,51.547774,3.814968,,,Netherlands,Rijkswaterstaat WaterWebservices
+wolphaartsdijk.schelphoekbadstrand,"Wolphaartsdijk, Schelphoek badstrand","Wolphaartsdijk, Schelphoek badstrand",51.542428,3.798573,,,Netherlands,Rijkswaterstaat WaterWebservices
+woudsend.slotermeer.noordwest.meetpaal29,"Woudsend, Slotermeer, noordwest, meetpaal 29","Woudsend, Slotermeer, noordwest, meetpaal 29",52.923313,5.647254,,,Netherlands,Rijkswaterstaat WaterWebservices
+yerseke,Yerseke,Yerseke,51.506154,4.07513,,,Netherlands,Rijkswaterstaat WaterWebservices
+yerseke.boeipk3,"Yerseke, boei PK3","Yerseke, boei PK3",51.476478,4.132287,,,Netherlands,Rijkswaterstaat WaterWebservices
+yerseke.postwegbadstrand,"Yerseke, Postweg badstrand","Yerseke, Postweg badstrand",51.502533,4.04369,,,Netherlands,Rijkswaterstaat WaterWebservices
+yerseke.verwaterplaats,"Yerseke, verwaterplaats","Yerseke, verwaterplaats",51.480973,4.100907,,,Netherlands,Rijkswaterstaat WaterWebservices
+zaandam.noordzeekanaal,"Zaandam, Noordzeekanaal",kilometer 18,52.418084,4.835905,,,Netherlands,Rijkswaterstaat WaterWebservices
+zaltbommel,Zaltbommel,Zaltbommel,51.815154,5.244645,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandkreek,Zandkreek,Zandkreek,51.549728,3.916702,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandkreek.boeiz1,"Zandkreek, boei Z1","Zandkreek, boei Z1",51.553926,3.907409,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandkreeksluis.binnen,"Zandkreeksluis, binnen","Zandkreeksluis, binnen",51.541655,3.862035,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandkreeksluis.inloop.2,"Zandkreeksluis, inloop, punt 02","Zandkreeksluis, inloop, punt 02",51.54422,3.869158,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandmotor.monsterterheijde,"Zandmotor, Monster Ter Heijde","Zandmotor, Monster Ter Heijde",52.030689,4.162157,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandvliet,Zandvliet,Zandvliet,51.37589,4.266899,,,Netherlands,Rijkswaterstaat WaterWebservices
+zandvoortaanzee,Zandvoort aan Zee,Zandvoort aan Zee,52.374011,4.522264,,,Netherlands,Rijkswaterstaat WaterWebservices
+zeeasterweg,Zeeasterweg,Wiertocht,52.50327,5.589709,,,Netherlands,Rijkswaterstaat WaterWebservices
+zeehavenkanaal.monding,"Zeehavenkanaal, monding","Zeehavenkanaal, monding",53.318607,7.006234,,,Netherlands,Rijkswaterstaat WaterWebservices
+zeelandbrug.noord,"Zeelandbrug, noord","Zeelandbrug, noord",51.626683,3.909728,,,Netherlands,Rijkswaterstaat WaterWebservices
+zeestrand.eemshotel.delfzijl,"Zeestrand, Eemshotel, Delfzijl","Zeestrand, Eemshotel, Delfzijl",53.334825,6.931385,,,Netherlands,Rijkswaterstaat WaterWebservices
+zeewolde.spiekweg.nijkerkertocht,"Zeewolde, Spiekweg, Nijkerkertocht","Zeewolde, Spiekweg, Nijkerkertocht",52.281876,5.46282,,,Netherlands,Rijkswaterstaat WaterWebservices
+zierikzee,Zierikzee,Zierikzee,51.642159,3.910813,,,Netherlands,Rijkswaterstaat WaterWebservices
+zierikzee.deval,"Zierikzee, De Val","Zierikzee, De Val",51.629683,3.891141,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.a,"Zijkanaal, A","Zijkanaal, A",52.469719,4.668299,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.b,"Zijkanaal, B","Zijkanaal, B",52.444624,4.687681,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.d1,"Zijkanaal, D-1","Zijkanaal, D-1",52.433425,4.751412,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.e,"Zijkanaal, E","Zijkanaal, E",52.429783,4.783636,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.e.2,"Zijkanaal, E, 2","Zijkanaal, E, 2",52.42788,4.784162,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.g,"Zijkanaal, G","Zijkanaal, G",52.430416,4.832179,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijkanaal.h,"Zijkanaal, H","Zijkanaal, H",52.42416,4.857661,,,Netherlands,Rijkswaterstaat WaterWebservices
+zijpe,Zijpe,Zijpe,51.644719,4.096983,,,Netherlands,Rijkswaterstaat WaterWebservices
+zilverstrand,Zilverstrand,Zilverstrand,52.329032,5.15171,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoelen,Zoelen,Zoelen,51.921115,5.42994,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoelen.beuningengemaal,Zoelen Beuningengemaal,Zoelen Beuningengemaal,51.92096,5.43391,,,Netherlands,Rijkswaterstaat WaterWebservices
+zonenvreugd.hoorn,"Zon en Vreugd, Hoorn","Zon en Vreugd, Hoorn",52.641573,5.046356,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoutelande.dishoek.badstrand,"Zoutelande, Dishoek, badstrand","Zoutelande, Dishoek, badstrand",51.471984,3.516144,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoutelande.smidshoekje.badstrand,"Zoutelande, Smidshoekje, badstrand","Zoutelande, Smidshoekje, badstrand",51.499037,3.482188,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoutkamp,Zoutkamp,Zoutkamp,53.337345,6.297096,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoutkamperlaag,Zoutkamperlaag,Zoutkamperlaag,53.429409,6.132651,,,Netherlands,Rijkswaterstaat WaterWebservices
+zoutkamperlaag.zeegat,"Zoutkamperlaag, zeegat","Zoutkamperlaag, zeegat",53.475102,6.079226,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidergat.boei44,"Zuidergat, boei 44","Zuidergat, boei 44",51.412701,4.03383,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidermeerdijk,Zuidermeerdijk,Zuidermeerdijk,52.602339,5.700133,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuiderspruit,Zuiderspruit,Zuiderspruit,53.421522,5.832327,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidhavenkm976p6,Zuidhaven km 976.6,Zuidhaven km 976.6,51.74286,4.717687,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidland.spui,"Zuidland, Spui","Zuidland, Spui",51.80555,4.282919,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidoord,Zuidoord,Zuidoord,51.793579,4.25306,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidoostlauwers.noordoost,"Zuid Oost Lauwers, noordoost","Zuid Oost Lauwers, noordoost",53.483166,6.452183,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidoostlauwers.noordwest,"Zuid Oost Lauwers, noordwest","Zuid Oost Lauwers, noordwest",53.49499,6.435902,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidoostlauwers.oost,"Zuid Oost Lauwers, oost","Zuid Oost Lauwers, oost",53.449146,6.51349,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidoostrak,Zuidoostrak,Zuidoostrak,53.120289,5.244562,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidoostrak.zuid,"Zuidoostrak, zuid","Zuidoostrak, zuid",53.10684,5.27223,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidwillemsvaart.sluis11,"Zuid-Willemsvaart, sluis 11","Zuid-Willemsvaart, sluis 11",51.395879,5.726735,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidwillemsvaart.sluis13,"Zuid-Willemsvaart, sluis 13","Zuid-Willemsvaart, sluis 13",51.330111,5.746621,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidwillemsvaart.sluis4.boven,"Zuid-Willemsvaart, sluis 4, boven","Zuid-Willemsvaart, sluis 4, boven",51.608956,5.530986,,,Netherlands,Rijkswaterstaat WaterWebservices
+zuidwillemsvaart.sluis6,"Zuid-Willemsvaart, sluis 6","Zuid-Willemsvaart, sluis 6",51.539578,5.631089,,,Netherlands,Rijkswaterstaat WaterWebservices
+zutphen,Zutphen,Zutphen,52.143276,6.189232,,,Netherlands,Rijkswaterstaat WaterWebservices
+zutphen.ijssel,"Zutphen, IJssel",noord,52.154,6.182,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwanenbad,Zwanenbad,Zwanenbad,51.93702,5.948729,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwartehaan,Zwarte Haan,Zwarte Haan,53.321874,5.619809,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwarteweg.heemskerk,"Zwarte Weg, Heemskerk","Zwarte Weg, Heemskerk",52.523991,4.595656,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwartsluis.binnen,"Zwartsluis, binnen","Zwartsluis, binnen",52.638486,6.078582,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwartsluis.gemaal.pomp1,Zwartsluis gemaal pomp1,vh pomp oost,52.637761,6.079753,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwartsluis.meppelerdiep,"Zwartsluis, Meppelerdiep",km 2.5,52.652215,6.092924,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwartsluis.zwartewater,"Zwartsluis, Zwarte Water",buiten,52.6357,6.076,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwolle,Zwolle,"Hasselterhaven, Zwarte Water",52.523047,6.069995,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwolle.ijssel,"Zwolle, IJssel",voorheen Katerveer,52.5086,6.053,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwolle.zwartewater.kanaal,"Zwolle, Zwarte Water, kanaal",voorheen Spooldersluis binnen,52.509831,6.054957,,,Netherlands,Rijkswaterstaat WaterWebservices
+zwolsehoek.badstrand,"Zwolse Hoek, badstrand","Zwolse Hoek, badstrand",52.615386,5.653051,,,Netherlands,Rijkswaterstaat WaterWebservices

--- a/rivretrieve/netherlands.py
+++ b/rivretrieve/netherlands.py
@@ -1,35 +1,4 @@
-"""Fetcher for Netherlands river gauge data from Rijkswaterstaat WaterWebservices.
-
-Data source:
-    - website: https://rijkswaterstaatdata.nl/waterdata/
-
-Supported variables:
-    - ``constants.DISCHARGE_DAILY_MEAN`` (m³/s)
-    - ``constants.DISCHARGE_INSTANT`` (m³/s)
-    - ``constants.STAGE_DAILY_MEAN`` (m)
-    - ``constants.STAGE_INSTANT`` (m)
-    - ``constants.WATER_TEMPERATURE_DAILY_MEAN`` (°C)
-    - ``constants.WATER_TEMPERATURE_INSTANT`` (°C)
-
-Data description and API:
-    - current API docs: https://ddapi20-waterwebservices.rijkswaterstaat.nl/swagger-ui/index.html
-
-Terms of use:
-    - see https://rijkswaterstaatdata.nl/waterdata/
-
-Notes:
-    - The official Rijkswaterstaat documentation was updated on March 10, 2026 and
-      states that the classic WaterWebservices will be retired at the end of April 2026.
-      This fetcher therefore targets the new ``ddapi20`` endpoints first and falls back
-      to the legacy service if needed.
-    - The Rijkswaterstaat catalog exposes discharge (``Q``), water level
-      (``WATHTE``), and water temperature (``T``) for surface water, which are mapped
-      to the corresponding RivRetrieve daily and instantaneous variables.
-    - Station metadata is filtered to stations that advertise at least one supported
-      surface-water variable.
-    - Rijkswaterstaat often serves observations at 10-minute resolution. This fetcher
-      retrieves raw observations in monthly windows and aggregates them to daily means.
-"""
+"""Fetcher for Netherlands river gauge data from Rijkswaterstaat WaterWebservices."""
 
 from __future__ import annotations
 
@@ -48,7 +17,43 @@ logger = logging.getLogger(__name__)
 
 
 class NetherlandsFetcher(base.RiverDataFetcher):
-    """Fetches Dutch river discharge data from Rijkswaterstaat WaterWebservices."""
+    """Fetches Dutch river gauge data from Rijkswaterstaat WaterWebservices.
+
+    Data source:
+        - website: https://rijkswaterstaatdata.nl/waterdata/
+
+    Supported variables:
+        - ``constants.DISCHARGE_DAILY_MEAN`` (m³/s)
+        - ``constants.DISCHARGE_INSTANT`` (m³/s)
+        - ``constants.STAGE_DAILY_MEAN`` (m)
+        - ``constants.STAGE_INSTANT`` (m)
+        - ``constants.WATER_TEMPERATURE_DAILY_MEAN`` (°C)
+        - ``constants.WATER_TEMPERATURE_INSTANT`` (°C)
+
+    Data description and API:
+        - current API docs: https://ddapi20-waterwebservices.rijkswaterstaat.nl/swagger-ui/index.html
+        - metadata endpoint: ``/METADATASERVICES/OphalenCatalogus``
+        - observations endpoint: ``/ONLINEWAARNEMINGENSERVICES/OphalenWaarnemingen``
+
+    Terms of use:
+        - see https://rijkswaterstaatdata.nl/waterdata/
+
+    Notes:
+        - The official Rijkswaterstaat documentation was updated on March 10, 2026 and
+          states that the classic WaterWebservices will be retired at the end of
+          April 2026. This fetcher therefore targets the new ``ddapi20`` endpoints
+          first and falls back to the legacy service if needed.
+        - The Rijkswaterstaat catalog exposes discharge (``Q``), water level
+          (``WATHTE``), and water temperature (``T``) for surface water, which are
+          mapped to the corresponding RivRetrieve daily and instantaneous variables.
+        - Station metadata is filtered to stations that advertise at least one
+          supported surface-water variable.
+        - Rijkswaterstaat often serves observations at 10-minute resolution. This
+          fetcher retrieves raw observations in monthly windows and aggregates them to
+          daily means for daily products.
+        - Stage values are converted from centimeters to meters.
+        - Provider sentinel missing values are filtered before aggregation.
+    """
 
     SOURCE = "Rijkswaterstaat WaterWebservices"
     COUNTRY = "Netherlands"

--- a/rivretrieve/netherlands.py
+++ b/rivretrieve/netherlands.py
@@ -1,0 +1,683 @@
+"""Fetcher for Netherlands river gauge data from Rijkswaterstaat WaterWebservices.
+
+Data source:
+    - website: https://rijkswaterstaatdata.nl/waterdata/
+
+Supported variables:
+    - ``constants.DISCHARGE_DAILY_MEAN`` (m³/s)
+    - ``constants.DISCHARGE_INSTANT`` (m³/s)
+    - ``constants.STAGE_DAILY_MEAN`` (m)
+    - ``constants.STAGE_INSTANT`` (m)
+    - ``constants.WATER_TEMPERATURE_DAILY_MEAN`` (°C)
+    - ``constants.WATER_TEMPERATURE_INSTANT`` (°C)
+
+Data description and API:
+    - current API docs: https://ddapi20-waterwebservices.rijkswaterstaat.nl/swagger-ui/index.html
+
+Terms of use:
+    - see https://rijkswaterstaatdata.nl/waterdata/
+
+Notes:
+    - The official Rijkswaterstaat documentation was updated on March 10, 2026 and
+      states that the classic WaterWebservices will be retired at the end of April 2026.
+      This fetcher therefore targets the new ``ddapi20`` endpoints first and falls back
+      to the legacy service if needed.
+    - The Rijkswaterstaat catalog exposes discharge (``Q``), water level
+      (``WATHTE``), and water temperature (``T``) for surface water, which are mapped
+      to the corresponding RivRetrieve daily and instantaneous variables.
+    - Station metadata is filtered to stations that advertise at least one supported
+      surface-water variable.
+    - Rijkswaterstaat often serves observations at 10-minute resolution. This fetcher
+      retrieves raw observations in monthly windows and aggregates them to daily means.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from typing import Any, Optional
+
+import numpy as np
+import pandas as pd
+import requests
+from pyproj import Transformer
+
+from . import base, constants, utils
+
+logger = logging.getLogger(__name__)
+
+
+class NetherlandsFetcher(base.RiverDataFetcher):
+    """Fetches Dutch river discharge data from Rijkswaterstaat WaterWebservices."""
+
+    SOURCE = "Rijkswaterstaat WaterWebservices"
+    COUNTRY = "Netherlands"
+    LOCAL_TIMEZONE = "Europe/Amsterdam"
+    CATALOG_ENDPOINTS = (
+        "https://ddapi20-waterwebservices.rijkswaterstaat.nl/METADATASERVICES/OphalenCatalogus",
+        "https://waterwebservices.rijkswaterstaat.nl/METADATASERVICES_DBO/OphalenCatalogus",
+    )
+    DATA_ENDPOINTS = (
+        "https://ddapi20-waterwebservices.rijkswaterstaat.nl/ONLINEWAARNEMINGENSERVICES/OphalenWaarnemingen",
+        "https://waterwebservices.rijkswaterstaat.nl/ONLINEWAARNEMINGENSERVICES_DBO/OphalenWaarnemingen",
+    )
+    VARIABLE_MAP = {
+        constants.DISCHARGE_DAILY_MEAN: {
+            "aggregate_daily": True,
+            "variants": (
+                {
+                    "grootheid": "Q",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "m3/s",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 1.0,
+                },
+                {
+                    "grootheid": "Q",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "m3/d",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 1.0 / 86400.0,
+                },
+            ),
+        },
+        constants.DISCHARGE_INSTANT: {
+            "aggregate_daily": False,
+            "variants": (
+                {
+                    "grootheid": "Q",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "m3/s",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 1.0,
+                },
+                {
+                    "grootheid": "Q",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "m3/d",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 1.0 / 86400.0,
+                },
+            ),
+        },
+        constants.STAGE_DAILY_MEAN: {
+            "aggregate_daily": True,
+            "variants": (
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "NAP",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "MSL",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "TAW",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "PLAATSLR",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 0.01,
+                },
+            ),
+        },
+        constants.STAGE_INSTANT: {
+            "aggregate_daily": False,
+            "variants": (
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "NAP",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "MSL",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "TAW",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "PLAATSLR",
+                    "unit_factor": 0.01,
+                },
+                {
+                    "grootheid": "WATHTE",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "cm",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 0.01,
+                },
+            ),
+        },
+        constants.WATER_TEMPERATURE_DAILY_MEAN: {
+            "aggregate_daily": True,
+            "variants": (
+                {
+                    "grootheid": "T",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "oC",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 1.0,
+                },
+            ),
+        },
+        constants.WATER_TEMPERATURE_INSTANT: {
+            "aggregate_daily": False,
+            "variants": (
+                {
+                    "grootheid": "T",
+                    "compartiment_code": "OW",
+                    "compartment_names": {"Oppervlaktewater"},
+                    "eenheid": "oC",
+                    "hoedanigheid": "NVT",
+                    "unit_factor": 1.0,
+                },
+            ),
+        },
+    }
+    CATALOG_BODY = {
+        "CatalogusFilter": {
+            "Compartimenten": True,
+            "Grootheden": True,
+            "Parameters": True,
+            "Eenheden": True,
+            "Hoedanigheden": True,
+            "Groeperingen": False,
+        }
+    }
+
+    def __init__(self):
+        self._catalog_cache: Optional[dict[str, Any]] = None
+
+    @staticmethod
+    def get_cached_metadata() -> pd.DataFrame:
+        """Retrieves cached Netherlands gauge metadata."""
+        return utils.load_cached_metadata_csv("netherlands")
+
+    @staticmethod
+    def get_available_variables() -> tuple[str, ...]:
+        return tuple(NetherlandsFetcher.VARIABLE_MAP.keys())
+
+    @staticmethod
+    def _empty_metadata_frame() -> pd.DataFrame:
+        columns = [
+            constants.GAUGE_ID,
+            constants.STATION_NAME,
+            constants.RIVER,
+            constants.LATITUDE,
+            constants.LONGITUDE,
+            constants.ALTITUDE,
+            constants.AREA,
+            constants.COUNTRY,
+            constants.SOURCE,
+        ]
+        return pd.DataFrame(columns=columns).set_index(constants.GAUGE_ID)
+
+    @staticmethod
+    def _empty_data_frame(variable: str) -> pd.DataFrame:
+        return pd.DataFrame(columns=[constants.TIME_INDEX, variable]).set_index(constants.TIME_INDEX)
+
+    @staticmethod
+    def _clean_provider_value(value: Any) -> float:
+        numeric = pd.to_numeric(value, errors="coerce")
+        if pd.isna(numeric):
+            return np.nan
+        if abs(float(numeric)) >= 9.9e11:
+            return np.nan
+        return float(numeric)
+
+    def _request_json(self, endpoints: Iterable[str], body: dict[str, Any]) -> dict[str, Any]:
+        session = utils.requests_retry_session(
+            retries=6,
+            backoff_factor=1,
+            status_forcelist=(429, 500, 502, 503, 504),
+        )
+        last_error: Optional[Exception] = None
+
+        for endpoint in endpoints:
+            try:
+                response = session.post(endpoint, json=body, timeout=60)
+                response.raise_for_status()
+                return response.json()
+            except (requests.exceptions.RequestException, ValueError) as exc:
+                last_error = exc
+                logger.warning(f"Netherlands request failed for {endpoint}: {exc}")
+
+        if last_error is not None:
+            raise last_error
+        raise RuntimeError("No endpoints were configured for NetherlandsFetcher.")
+
+    def _get_catalog(self) -> dict[str, Any]:
+        if self._catalog_cache is None:
+            self._catalog_cache = self._request_json(self.CATALOG_ENDPOINTS, self.CATALOG_BODY)
+        return self._catalog_cache
+
+    @staticmethod
+    def _as_frame(payload: Any) -> pd.DataFrame:
+        if isinstance(payload, list) and payload:
+            return pd.DataFrame(payload)
+        if isinstance(payload, list):
+            return pd.DataFrame()
+        if isinstance(payload, dict):
+            return pd.DataFrame([payload])
+        return pd.DataFrame()
+
+    @staticmethod
+    def _pick_column(df: pd.DataFrame, candidates: tuple[str, ...]) -> Optional[str]:
+        for candidate in candidates:
+            if candidate in df.columns:
+                return candidate
+        return None
+
+    @staticmethod
+    def _extract_nested_value(value: Any, *path: str) -> Any:
+        current = value
+        for key in path:
+            if isinstance(current, dict):
+                current = current.get(key)
+            else:
+                return None
+        return current
+
+    @classmethod
+    def _series_nested_value(cls, series: pd.Series, *path: str) -> pd.Series:
+        return series.apply(lambda value: cls._extract_nested_value(value, *path))
+
+    @staticmethod
+    def _aligned_numeric_series(df: pd.DataFrame, columns: tuple[str, ...], default: float = np.nan) -> pd.Series:
+        for column in columns:
+            if column in df.columns:
+                return pd.to_numeric(df[column], errors="coerce")
+        return pd.Series(default, index=df.index, dtype=float)
+
+    @classmethod
+    def _extract_epsg_series(cls, df: pd.DataFrame) -> pd.Series:
+        if "Coordinatenstelsel" not in df.columns:
+            return pd.Series(25831, index=df.index, dtype="Int64")
+
+        raw = df["Coordinatenstelsel"]
+        if raw.apply(lambda value: isinstance(value, dict)).any():
+            raw = raw.apply(
+                lambda value: cls._extract_nested_value(value, "EPSG")
+                or cls._extract_nested_value(value, "Code")
+                or cls._extract_nested_value(value, "Waarde")
+                or cls._extract_nested_value(value, "Id")
+                if isinstance(value, dict)
+                else value
+            )
+
+        return pd.to_numeric(raw, errors="coerce").fillna(25831).astype("Int64")
+
+    @staticmethod
+    def _build_transformers(epsg_codes: Iterable[int]) -> dict[int, Transformer]:
+        transformers: dict[int, Transformer] = {}
+        for epsg in epsg_codes:
+            try:
+                transformers[epsg] = Transformer.from_crs(f"EPSG:{epsg}", "EPSG:4326", always_xy=True)
+            except Exception:
+                logger.warning(f"Skipping unsupported CRS EPSG:{epsg} in Netherlands metadata.")
+        return transformers
+
+    @classmethod
+    def _transform_coordinates(cls, df: pd.DataFrame) -> tuple[pd.Series, pd.Series]:
+        if df.empty:
+            return pd.Series(dtype=float), pd.Series(dtype=float)
+
+        direct_lat = cls._aligned_numeric_series(df, ("Lat", "lat", "Latitude", "latitude"))
+        direct_lon = cls._aligned_numeric_series(df, ("Lon", "lon", "Longitude", "longitude"))
+        if direct_lat.notna().any() and direct_lon.notna().any():
+            return direct_lon, direct_lat
+
+        x = cls._aligned_numeric_series(df, ("X", "x"))
+        y = cls._aligned_numeric_series(df, ("Y", "y"))
+        epsg = cls._extract_epsg_series(df)
+
+        lon = pd.Series(np.nan, index=df.index, dtype=float)
+        lat = pd.Series(np.nan, index=df.index, dtype=float)
+        valid = x.notna() & y.notna() & epsg.notna()
+        transformers = cls._build_transformers(sorted(set(epsg[valid].astype(int).tolist())))
+
+        for code, transformer in transformers.items():
+            mask = valid & (epsg.astype("Int64") == code)
+            if not mask.any():
+                continue
+            transformed_lon, transformed_lat = transformer.transform(x[mask].to_numpy(), y[mask].to_numpy())
+            lon.loc[mask] = transformed_lon
+            lat.loc[mask] = transformed_lat
+
+        return lon, lat
+
+    def _get_supported_station_codes(self, variable: str) -> set[str]:
+        config = self.VARIABLE_MAP[variable]
+        catalog = self._get_catalog()
+        meta = self._as_frame(catalog.get("AquoMetadataLijst"))
+        locs = self._as_frame(catalog.get("LocatieLijst"))
+        xref = self._as_frame(catalog.get("AquoMetadataLocatieLijst"))
+        if meta.empty or locs.empty or xref.empty:
+            return set()
+
+        meta_key = self._pick_column(
+            meta, ("AquoMetadata_MessageID", "AquoMetadataMessageID", "AquoMetadataId", "AquoMetadata_ID", "MessageID")
+        )
+        xref_meta_key = self._pick_column(
+            xref, ("AquoMetaData_MessageID", "AquoMetadata_MessageID", "AquoMetadataMessageID", "AquoMetadataId")
+        )
+        xref_loc_key = self._pick_column(
+            xref, ("Locatie_MessageID", "LocatieMessageID", "LocatieId", "Locatie_ID", "MessageID_Locatie")
+        )
+        loc_key = self._pick_column(
+            locs,
+            ("MessageID", "MessageId", "Locatie_MessageID", "LocatieMessageID", "LocatieId"),
+        )
+        loc_code = self._pick_column(locs, ("Code", "LocatieCode", "StationCode"))
+        if not all([meta_key, xref_meta_key, xref_loc_key, loc_key, loc_code]):
+            return set()
+
+        meta = meta.copy()
+        meta["grootheid_code"] = (
+            self._series_nested_value(meta["Grootheid"], "Code") if "Grootheid" in meta.columns else None
+        )
+        meta["compartment_code"] = (
+            self._series_nested_value(meta["Compartiment"], "Code") if "Compartiment" in meta.columns else None
+        )
+        meta["compartment_name"] = (
+            self._series_nested_value(meta["Compartiment"], "Omschrijving")
+            if "Compartiment" in meta.columns
+            else None
+        )
+
+        allowed = pd.Series(False, index=meta.index)
+        for variant in config["variants"]:
+            variant_mask = meta["grootheid_code"].eq(variant["grootheid"]) & (
+                meta["compartment_code"].eq(variant["compartiment_code"])
+                | meta["compartment_name"].isin(variant["compartment_names"])
+            )
+            if variant.get("eenheid") is not None and "Eenheid" in meta.columns:
+                eenheid_code = self._series_nested_value(meta["Eenheid"], "Code")
+                variant_mask = variant_mask & eenheid_code.eq(variant["eenheid"])
+            if variant.get("hoedanigheid") is not None and "Hoedanigheid" in meta.columns:
+                hoedanigheid_code = self._series_nested_value(meta["Hoedanigheid"], "Code")
+                variant_mask = variant_mask & hoedanigheid_code.eq(variant["hoedanigheid"])
+            allowed = allowed | variant_mask
+        matching_meta = meta.loc[allowed, [meta_key]]
+        if matching_meta.empty:
+            return set()
+
+        matched_xref = xref[xref[xref_meta_key].isin(matching_meta[meta_key])]
+        if matched_xref.empty:
+            return set()
+
+        matched_locs = locs[locs[loc_key].isin(matched_xref[xref_loc_key])]
+        return set(matched_locs[loc_code].dropna().astype(str).str.strip())
+
+    def get_metadata(self) -> pd.DataFrame:
+        """Fetches live metadata for Dutch discharge stations."""
+        catalog = self._get_catalog()
+        locs = self._as_frame(catalog.get("LocatieLijst"))
+        if locs.empty:
+            return self._empty_metadata_frame()
+
+        loc_code = self._pick_column(locs, ("Code", "LocatieCode", "StationCode"))
+        name_col = self._pick_column(locs, ("Naam", "LocatieNaam", "StationNaam"))
+        if loc_code is None:
+            return self._empty_metadata_frame()
+
+        supported_codes: set[str] = set()
+        for variable in self.get_available_variables():
+            supported_codes.update(self._get_supported_station_codes(variable))
+        if supported_codes:
+            locs = locs[locs[loc_code].astype(str).str.strip().isin(supported_codes)]
+        if locs.empty:
+            return self._empty_metadata_frame()
+
+        river_series = pd.Series(np.nan, index=locs.index, dtype=object)
+        for column_name in ("Water", "Waternaam", "Omschrijving"):
+            if column_name in locs.columns:
+                river_series = locs[column_name]
+                break
+
+        lon, lat = self._transform_coordinates(locs)
+        df = pd.DataFrame(
+            {
+                constants.GAUGE_ID: locs[loc_code].astype(str).str.strip(),
+                constants.STATION_NAME: locs[name_col].astype(str).str.strip() if name_col else np.nan,
+                constants.RIVER: river_series,
+                constants.LATITUDE: lat,
+                constants.LONGITUDE: lon,
+                constants.ALTITUDE: np.nan,
+                constants.AREA: np.nan,
+                constants.COUNTRY: self.COUNTRY,
+                constants.SOURCE: self.SOURCE,
+            }
+        )
+        df = df.drop_duplicates(subset=[constants.GAUGE_ID]).sort_values(constants.GAUGE_ID)
+        return df.set_index(constants.GAUGE_ID)
+
+    @staticmethod
+    def _monthly_windows(start_date: str, end_date: str) -> list[tuple[pd.Timestamp, pd.Timestamp]]:
+        start = pd.Timestamp(start_date)
+        end = pd.Timestamp(end_date)
+        if pd.isna(start) or pd.isna(end) or start > end:
+            return []
+
+        windows: list[tuple[pd.Timestamp, pd.Timestamp]] = []
+        current = start
+        while current <= end:
+            next_month = (current + pd.offsets.MonthBegin(1)).normalize()
+            window_end = min(end, next_month - pd.Timedelta(days=1))
+            windows.append((current, window_end))
+            current = window_end + pd.Timedelta(days=1)
+        return windows
+
+    def _get_location_payload(self, gauge_id: str) -> dict[str, Any]:
+        catalog = self._get_catalog()
+        locs = self._as_frame(catalog.get("LocatieLijst"))
+        if locs.empty:
+            return {"Code": gauge_id}
+
+        loc_code = self._pick_column(locs, ("Code", "LocatieCode", "StationCode"))
+        if loc_code is None:
+            return {"Code": gauge_id}
+
+        matches = locs[locs[loc_code].astype(str).str.strip() == str(gauge_id)]
+        if matches.empty:
+            return {"Code": gauge_id}
+
+        row = matches.iloc[0]
+        location = {"Code": str(gauge_id)}
+        x = pd.to_numeric(pd.Series([row.get("X")]), errors="coerce").iloc[0]
+        y = pd.to_numeric(pd.Series([row.get("Y")]), errors="coerce").iloc[0]
+        if pd.notna(x) and pd.notna(y):
+            location["X"] = float(x)
+            location["Y"] = float(y)
+        return location
+
+    def _download_data(
+        self,
+        gauge_id: str,
+        variable: str,
+        start_date: str,
+        end_date: str,
+    ) -> list[dict[str, Any]]:
+        config = self.VARIABLE_MAP[variable]
+        location = self._get_location_payload(str(gauge_id))
+        payloads: list[dict[str, Any]] = []
+
+        for window_start, window_end in self._monthly_windows(start_date, end_date):
+            for rank, variant in enumerate(config["variants"]):
+                aquo_metadata: dict[str, Any] = {
+                    "Compartiment": {"Code": variant["compartiment_code"]},
+                    "Grootheid": {"Code": variant["grootheid"]},
+                }
+                if variant.get("eenheid") is not None:
+                    aquo_metadata["Eenheid"] = {"Code": variant["eenheid"]}
+                if variant.get("hoedanigheid") is not None:
+                    aquo_metadata["Hoedanigheid"] = {"Code": variant["hoedanigheid"]}
+
+                body = {
+                    "Locatie": location,
+                    "AquoPlusWaarnemingMetadata": {"AquoMetadata": aquo_metadata},
+                    "Periode": {
+                        "Begindatumtijd": window_start.strftime("%Y-%m-%dT00:00:00.000+00:00"),
+                        "Einddatumtijd": window_end.strftime("%Y-%m-%dT23:59:59.999+00:00"),
+                    },
+                }
+                payload = self._request_json(self.DATA_ENDPOINTS, body)
+                if payload:
+                    payloads.append(
+                        {
+                            "payload": payload,
+                            "rank": rank,
+                            "unit_factor": variant["unit_factor"],
+                        }
+                    )
+
+        return payloads
+
+    @staticmethod
+    def _flatten_measurement_lists(payload: dict[str, Any]) -> list[dict[str, Any]]:
+        observation_list = payload.get("WaarnemingenLijst")
+        if observation_list is None:
+            return []
+
+        containers: list[Any]
+        if isinstance(observation_list, list):
+            containers = observation_list
+        else:
+            containers = [observation_list]
+
+        measurements: list[dict[str, Any]] = []
+        for container in containers:
+            if isinstance(container, dict):
+                value = container.get("MetingenLijst")
+                if isinstance(value, list):
+                    measurements.extend([item for item in value if isinstance(item, dict)])
+                elif isinstance(value, dict):
+                    measurements.append(value)
+        return measurements
+
+    @classmethod
+    def _parse_data(
+        cls,
+        gauge_id: str,
+        raw_data: list[dict[str, Any]],
+        variable: str,
+    ) -> pd.DataFrame:
+        """Parses Rijkswaterstaat payloads into the standard RivRetrieve layout."""
+        if not raw_data:
+            return cls._empty_data_frame(variable)
+
+        rows: list[dict[str, Any]] = []
+        config = cls.VARIABLE_MAP[variable]
+        for payload_info in raw_data:
+            payload = payload_info["payload"]
+            for measurement in cls._flatten_measurement_lists(payload):
+                timestamp = (
+                    measurement.get("Tijdstip") or measurement.get("Tijdstempel") or measurement.get("Datumtijd")
+                )
+                numeric_value = cls._extract_nested_value(measurement.get("Meetwaarde"), "Waarde_Numeriek")
+                rows.append(
+                    {
+                        constants.TIME_INDEX: pd.to_datetime(timestamp, utc=True, errors="coerce"),
+                        variable: cls._clean_provider_value(numeric_value) * payload_info["unit_factor"],
+                        "_rank": payload_info["rank"],
+                    }
+                )
+
+        if not rows:
+            return cls._empty_data_frame(variable)
+
+        df = pd.DataFrame(rows).dropna(subset=[constants.TIME_INDEX, variable])
+        if df.empty:
+            return cls._empty_data_frame(variable)
+
+        df[constants.TIME_INDEX] = df[constants.TIME_INDEX].dt.tz_convert(cls.LOCAL_TIMEZONE).dt.tz_localize(None)
+        df = df.sort_values([constants.TIME_INDEX, "_rank"])
+        df = df.drop_duplicates(subset=[constants.TIME_INDEX], keep="first")
+
+        if config["aggregate_daily"]:
+            df[constants.TIME_INDEX] = df[constants.TIME_INDEX].dt.floor("D")
+            df = df.groupby(constants.TIME_INDEX, as_index=False)[variable].mean()
+        else:
+            df = df[[constants.TIME_INDEX, variable]]
+
+        df = df.drop_duplicates(subset=[constants.TIME_INDEX]).sort_values(constants.TIME_INDEX)
+        return df.set_index(constants.TIME_INDEX)
+
+    def get_data(
+        self,
+        gauge_id: str,
+        variable: str,
+        start_date: Optional[str] = None,
+        end_date: Optional[str] = None,
+    ) -> pd.DataFrame:
+        """Fetches and parses Dutch time series data for a specific gauge and variable."""
+        start_date = utils.format_start_date(start_date)
+        end_date = utils.format_end_date(end_date)
+
+        if variable not in self.get_available_variables():
+            raise ValueError(f"Unsupported variable: {variable}")
+
+        try:
+            raw_data = self._download_data(str(gauge_id), variable, start_date, end_date)
+            df = self._parse_data(str(gauge_id), raw_data, variable)
+        except Exception as exc:
+            logger.error(f"Failed to get data for site {gauge_id}, variable {variable}: {exc}")
+            return self._empty_data_frame(variable)
+
+        if df.empty:
+            return df
+
+        start_dt = pd.to_datetime(start_date)
+        end_dt = pd.to_datetime(end_date)
+        if "instantaneous" in variable:
+            end_dt = end_dt + pd.Timedelta(days=1)
+            return df[(df.index >= start_dt) & (df.index < end_dt)]
+
+        return df[(df.index >= start_dt) & (df.index <= end_dt)]

--- a/rivretrieve/netherlands.py
+++ b/rivretrieve/netherlands.py
@@ -344,12 +344,14 @@ class NetherlandsFetcher(base.RiverDataFetcher):
         raw = df["Coordinatenstelsel"]
         if raw.apply(lambda value: isinstance(value, dict)).any():
             raw = raw.apply(
-                lambda value: cls._extract_nested_value(value, "EPSG")
-                or cls._extract_nested_value(value, "Code")
-                or cls._extract_nested_value(value, "Waarde")
-                or cls._extract_nested_value(value, "Id")
-                if isinstance(value, dict)
-                else value
+                lambda value: (
+                    cls._extract_nested_value(value, "EPSG")
+                    or cls._extract_nested_value(value, "Code")
+                    or cls._extract_nested_value(value, "Waarde")
+                    or cls._extract_nested_value(value, "Id")
+                    if isinstance(value, dict)
+                    else value
+                )
             )
 
         return pd.to_numeric(raw, errors="coerce").fillna(25831).astype("Int64")

--- a/rivretrieve/netherlands.py
+++ b/rivretrieve/netherlands.py
@@ -32,17 +32,11 @@ class NetherlandsFetcher(base.RiverDataFetcher):
 
     Data description and API:
         - current API docs: https://ddapi20-waterwebservices.rijkswaterstaat.nl/swagger-ui/index.html
-        - metadata endpoint: ``/METADATASERVICES/OphalenCatalogus``
-        - observations endpoint: ``/ONLINEWAARNEMINGENSERVICES/OphalenWaarnemingen``
 
     Terms of use:
         - see https://rijkswaterstaatdata.nl/waterdata/
 
     Notes:
-        - The official Rijkswaterstaat documentation was updated on March 10, 2026 and
-          states that the classic WaterWebservices will be retired at the end of
-          April 2026. This fetcher therefore targets the new ``ddapi20`` endpoints
-          first and falls back to the legacy service if needed.
         - The Rijkswaterstaat catalog exposes discharge (``Q``), water level
           (``WATHTE``), and water temperature (``T``) for surface water, which are
           mapped to the corresponding RivRetrieve daily and instantaneous variables.
@@ -462,7 +456,11 @@ class NetherlandsFetcher(base.RiverDataFetcher):
         return set(matched_locs[loc_code].dropna().astype(str).str.strip())
 
     def get_metadata(self) -> pd.DataFrame:
-        """Fetches live metadata for Dutch discharge stations."""
+        """Fetches live metadata for Dutch surface-water stations.
+
+        Returns a DataFrame indexed by ``constants.GAUGE_ID`` and filtered to
+        stations that advertise at least one supported RivRetrieve variable.
+        """
         catalog = self._get_catalog()
         locs = self._as_frame(catalog.get("LocatieLijst"))
         if locs.empty:
@@ -662,7 +660,30 @@ class NetherlandsFetcher(base.RiverDataFetcher):
         start_date: Optional[str] = None,
         end_date: Optional[str] = None,
     ) -> pd.DataFrame:
-        """Fetches and parses Dutch time series data for a specific gauge and variable."""
+        """Fetches and parses Dutch time series data for a specific gauge and variable.
+
+        This method retrieves the requested data from Rijkswaterstaat's observation API,
+        parses it, and returns it in a standardized pandas DataFrame format.
+
+        Args:
+            gauge_id: The site-specific identifier for the gauge.
+            variable: The variable to fetch. Must be one of the strings listed
+                in the fetcher's ``get_available_variables()`` output.
+                These are typically defined in ``rivretrieve.constants``.
+            start_date: Optional start date for the data retrieval in 'YYYY-MM-DD' format.
+                If None, data is fetched from the earliest available date.
+            end_date: Optional end date for the data retrieval in 'YYYY-MM-DD' format.
+                If None, data is fetched up to the latest available date.
+
+        Returns:
+            pd.DataFrame: A pandas DataFrame indexed by datetime objects (``constants.TIME_INDEX``)
+            with a single column named after the requested ``variable``. The DataFrame
+            will be empty if no data is found for the given parameters.
+
+        Raises:
+            ValueError: If the requested ``variable`` is not supported by this fetcher.
+            Exception: For unexpected download or parsing errors.
+        """
         start_date = utils.format_start_date(start_date)
         end_date = utils.format_end_date(end_date)
 

--- a/rivretrieve/netherlands.py
+++ b/rivretrieve/netherlands.py
@@ -35,18 +35,6 @@ class NetherlandsFetcher(base.RiverDataFetcher):
 
     Terms of use:
         - see https://rijkswaterstaatdata.nl/waterdata/
-
-    Notes:
-        - The Rijkswaterstaat catalog exposes discharge (``Q``), water level
-          (``WATHTE``), and water temperature (``T``) for surface water, which are
-          mapped to the corresponding RivRetrieve daily and instantaneous variables.
-        - Station metadata is filtered to stations that advertise at least one
-          supported surface-water variable.
-        - Rijkswaterstaat often serves observations at 10-minute resolution. This
-          fetcher retrieves raw observations in monthly windows and aggregates them to
-          daily means for daily products.
-        - Stage values are converted from centimeters to meters.
-        - Provider sentinel missing values are filtered before aggregation.
     """
 
     SOURCE = "Rijkswaterstaat WaterWebservices"

--- a/rivretrieve/netherlands.py
+++ b/rivretrieve/netherlands.py
@@ -427,9 +427,7 @@ class NetherlandsFetcher(base.RiverDataFetcher):
             self._series_nested_value(meta["Compartiment"], "Code") if "Compartiment" in meta.columns else None
         )
         meta["compartment_name"] = (
-            self._series_nested_value(meta["Compartiment"], "Omschrijving")
-            if "Compartiment" in meta.columns
-            else None
+            self._series_nested_value(meta["Compartiment"], "Omschrijving") if "Compartiment" in meta.columns else None
         )
 
         allowed = pd.Series(False, index=meta.index)

--- a/tests/test_data/netherlands_catalog_sample.json
+++ b/tests/test_data/netherlands_catalog_sample.json
@@ -1,0 +1,113 @@
+{
+  "AquoMetadataLijst": [
+    {
+      "AquoMetadata_MessageID": "meta-discharge",
+      "Compartiment": {
+        "Code": "OW",
+        "Omschrijving": "Oppervlaktewater"
+      },
+      "Grootheid": {
+        "Code": "Q",
+        "Omschrijving": "Debiet"
+      },
+      "Eenheid": {
+        "Code": "m3/s"
+      },
+      "Hoedanigheid": {
+        "Code": "NVT"
+      }
+    },
+    {
+      "AquoMetadata_MessageID": "meta-stage",
+      "Compartiment": {
+        "Code": "OW",
+        "Omschrijving": "Oppervlaktewater"
+      },
+      "Grootheid": {
+        "Code": "WATHTE",
+        "Omschrijving": "Waterhoogte"
+      },
+      "Eenheid": {
+        "Code": "cm"
+      },
+      "Hoedanigheid": {
+        "Code": "NAP"
+      }
+    },
+    {
+      "AquoMetadata_MessageID": "meta-temperature",
+      "Compartiment": {
+        "Code": "OW",
+        "Omschrijving": "Oppervlaktewater"
+      },
+      "Grootheid": {
+        "Code": "T",
+        "Omschrijving": "Temperatuur"
+      },
+      "Eenheid": {
+        "Code": "oC"
+      },
+      "Hoedanigheid": {
+        "Code": "NVT"
+      }
+    },
+    {
+      "AquoMetadata_MessageID": "meta-groundwater",
+      "Compartiment": {
+        "Code": "GW",
+        "Omschrijving": "Grondwater"
+      },
+      "Grootheid": {
+        "Code": "Q",
+        "Omschrijving": "Debiet"
+      }
+    }
+  ],
+  "LocatieLijst": [
+    {
+      "MessageID": "loc-1",
+      "Code": "lobith",
+      "Naam": "Lobith",
+      "Waternaam": "Rijn",
+      "X": 6.114,
+      "Y": 51.8621,
+      "Coordinatenstelsel": 4326
+    },
+    {
+      "MessageID": "loc-2",
+      "Code": "borgharen",
+      "Naam": "Borgharen",
+      "Waternaam": "Maas",
+      "X": 5.7066,
+      "Y": 50.8774,
+      "Coordinatenstelsel": 4326
+    },
+    {
+      "MessageID": "loc-3",
+      "Code": "groundwater-only",
+      "Naam": "Groundwater only",
+      "Waternaam": "Aquifer",
+      "X": 5.0,
+      "Y": 52.0,
+      "Coordinatenstelsel": 4326
+    }
+  ],
+  "AquoMetadataLocatieLijst": [
+    {
+      "AquoMetaData_MessageID": "meta-discharge",
+      "Locatie_MessageID": "loc-1"
+    },
+    {
+      "AquoMetaData_MessageID": "meta-discharge",
+      "Locatie_MessageID": "loc-2"
+    },
+    {
+      "AquoMetaData_MessageID": "meta-temperature",
+      "Locatie_MessageID": "loc-2"
+    },
+    {
+      "AquoMetaData_MessageID": "meta-groundwater",
+      "Locatie_MessageID": "loc-3"
+    }
+  ]
+}

--- a/tests/test_data/netherlands_discharge_sample.json
+++ b/tests/test_data/netherlands_discharge_sample.json
@@ -1,0 +1,32 @@
+{
+  "WaarnemingenLijst": [
+    {
+      "MetingenLijst": [
+        {
+          "Tijdstip": "2025-01-01T00:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 100.0
+          }
+        },
+        {
+          "Tijdstip": "2025-01-01T12:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 110.0
+          }
+        },
+        {
+          "Tijdstip": "2025-01-02T00:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 120.0
+          }
+        },
+        {
+          "Tijdstip": "2025-01-02T12:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 140.0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_data/netherlands_stage_sample.json
+++ b/tests/test_data/netherlands_stage_sample.json
@@ -1,0 +1,20 @@
+{
+  "WaarnemingenLijst": [
+    {
+      "MetingenLijst": [
+        {
+          "Tijdstip": "2025-01-01T00:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 120.0
+          }
+        },
+        {
+          "Tijdstip": "2025-01-01T12:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 140.0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_data/netherlands_temperature_sample.json
+++ b/tests/test_data/netherlands_temperature_sample.json
@@ -1,0 +1,26 @@
+{
+  "WaarnemingenLijst": [
+    {
+      "MetingenLijst": [
+        {
+          "Tijdstip": "2025-01-01T00:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 10.0
+          }
+        },
+        {
+          "Tijdstip": "2025-01-01T12:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 1000000000000.0
+          }
+        },
+        {
+          "Tijdstip": "2025-01-01T18:00:00.000+00:00",
+          "Meetwaarde": {
+            "Waarde_Numeriek": 14.0
+          }
+        }
+      ]
+    }
+  ]
+}

--- a/tests/test_netherlands.py
+++ b/tests/test_netherlands.py
@@ -1,0 +1,186 @@
+import json
+import os
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+from pandas.testing import assert_frame_equal
+
+from rivretrieve import NetherlandsFetcher, constants
+
+
+class TestNetherlandsFetcher(unittest.TestCase):
+    def setUp(self):
+        self.fetcher = NetherlandsFetcher()
+        self.test_data_dir = Path(os.path.dirname(__file__)) / "test_data"
+
+    def _load_json(self, filename):
+        with open(self.test_data_dir / filename, "r", encoding="utf-8") as f:
+            return json.load(f)
+
+    @staticmethod
+    def _mock_response(payload):
+        response = MagicMock()
+        response.json.return_value = payload
+        response.raise_for_status = MagicMock()
+        return response
+
+    @patch("rivretrieve.utils.requests_retry_session")
+    def test_get_metadata_filters_to_supported_discharge_surface_water_stations(self, mock_requests_session):
+        mock_session = MagicMock()
+        mock_requests_session.return_value = mock_session
+        mock_session.post.return_value = self._mock_response(self._load_json("netherlands_catalog_sample.json"))
+
+        result_df = self.fetcher.get_metadata()
+
+        self.assertEqual(list(result_df.index), ["borgharen", "lobith"])
+        self.assertEqual(result_df.loc["lobith", constants.STATION_NAME], "Lobith")
+        self.assertEqual(result_df.loc["lobith", constants.RIVER], "Rijn")
+        self.assertAlmostEqual(result_df.loc["lobith", constants.LATITUDE], 51.8621, places=4)
+        self.assertAlmostEqual(result_df.loc["lobith", constants.LONGITUDE], 6.1140, places=4)
+        self.assertEqual(result_df.loc["lobith", constants.COUNTRY], "Netherlands")
+        self.assertEqual(result_df.loc["lobith", constants.SOURCE], self.fetcher.SOURCE)
+        self.assertEqual(mock_session.post.call_count, 1)
+
+    def test_available_variables(self):
+        self.assertEqual(
+            self.fetcher.get_available_variables(),
+            (
+                constants.DISCHARGE_DAILY_MEAN,
+                constants.DISCHARGE_INSTANT,
+                constants.STAGE_DAILY_MEAN,
+                constants.STAGE_INSTANT,
+                constants.WATER_TEMPERATURE_DAILY_MEAN,
+                constants.WATER_TEMPERATURE_INSTANT,
+            ),
+        )
+
+    @patch("rivretrieve.utils.requests_retry_session")
+    def test_get_data_daily_discharge(self, mock_requests_session):
+        mock_session = MagicMock()
+        mock_requests_session.return_value = mock_session
+        mock_session.post.side_effect = [
+            self._mock_response(self._load_json("netherlands_catalog_sample.json")),
+            self._mock_response(self._load_json("netherlands_discharge_sample.json")),
+            self._mock_response({}),
+        ]
+
+        result_df = self.fetcher.get_data(
+            gauge_id="lobith",
+            variable=constants.DISCHARGE_DAILY_MEAN,
+            start_date="2025-01-01",
+            end_date="2025-01-02",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                constants.TIME_INDEX: pd.to_datetime(["2025-01-01", "2025-01-02"]),
+                constants.DISCHARGE_DAILY_MEAN: [105.0, 130.0],
+            }
+        ).set_index(constants.TIME_INDEX)
+
+        assert_frame_equal(result_df, expected_df)
+        self.assertEqual(mock_session.post.call_count, 3)
+        data_body = mock_session.post.call_args_list[1].kwargs["json"]
+        self.assertEqual(data_body["Locatie"]["Code"], "lobith")
+        self.assertEqual(data_body["AquoPlusWaarnemingMetadata"]["AquoMetadata"]["Grootheid"]["Code"], "Q")
+        self.assertEqual(data_body["AquoPlusWaarnemingMetadata"]["AquoMetadata"]["Eenheid"]["Code"], "m3/s")
+
+    @patch("rivretrieve.utils.requests_retry_session")
+    def test_get_data_instant_discharge(self, mock_requests_session):
+        mock_session = MagicMock()
+        mock_requests_session.return_value = mock_session
+        mock_session.post.side_effect = [
+            self._mock_response(self._load_json("netherlands_catalog_sample.json")),
+            self._mock_response(self._load_json("netherlands_discharge_sample.json")),
+            self._mock_response({}),
+        ]
+
+        result_df = self.fetcher.get_data(
+            gauge_id="lobith",
+            variable=constants.DISCHARGE_INSTANT,
+            start_date="2025-01-01",
+            end_date="2025-01-02",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                constants.TIME_INDEX: pd.to_datetime(
+                    [
+                        "2025-01-01 01:00:00",
+                        "2025-01-01 13:00:00",
+                        "2025-01-02 01:00:00",
+                        "2025-01-02 13:00:00",
+                    ]
+                ),
+                constants.DISCHARGE_INSTANT: [100.0, 110.0, 120.0, 140.0],
+            }
+        ).set_index(constants.TIME_INDEX)
+
+        assert_frame_equal(result_df, expected_df)
+
+    @patch("rivretrieve.utils.requests_retry_session")
+    def test_get_data_daily_stage_converts_cm_to_m(self, mock_requests_session):
+        mock_session = MagicMock()
+        mock_requests_session.return_value = mock_session
+        mock_session.post.side_effect = [
+            self._mock_response(self._load_json("netherlands_catalog_sample.json")),
+            self._mock_response(self._load_json("netherlands_stage_sample.json")),
+            self._mock_response({}),
+            self._mock_response({}),
+            self._mock_response({}),
+            self._mock_response({}),
+        ]
+
+        result_df = self.fetcher.get_data(
+            gauge_id="lobith",
+            variable=constants.STAGE_DAILY_MEAN,
+            start_date="2025-01-01",
+            end_date="2025-01-01",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                constants.TIME_INDEX: pd.to_datetime(["2025-01-01"]),
+                constants.STAGE_DAILY_MEAN: [1.3],
+            }
+        ).set_index(constants.TIME_INDEX)
+
+        assert_frame_equal(result_df, expected_df)
+        first_stage_body = mock_session.post.call_args_list[1].kwargs["json"]
+        self.assertEqual(first_stage_body["AquoPlusWaarnemingMetadata"]["AquoMetadata"]["Grootheid"]["Code"], "WATHTE")
+        self.assertEqual(first_stage_body["AquoPlusWaarnemingMetadata"]["AquoMetadata"]["Hoedanigheid"]["Code"], "NAP")
+
+    @patch("rivretrieve.utils.requests_retry_session")
+    def test_get_data_daily_temperature_filters_provider_sentinel_values(self, mock_requests_session):
+        mock_session = MagicMock()
+        mock_requests_session.return_value = mock_session
+        mock_session.post.side_effect = [
+            self._mock_response(self._load_json("netherlands_catalog_sample.json")),
+            self._mock_response(self._load_json("netherlands_temperature_sample.json")),
+        ]
+
+        result_df = self.fetcher.get_data(
+            gauge_id="borgharen",
+            variable=constants.WATER_TEMPERATURE_DAILY_MEAN,
+            start_date="2025-01-01",
+            end_date="2025-01-01",
+        )
+
+        expected_df = pd.DataFrame(
+            {
+                constants.TIME_INDEX: pd.to_datetime(["2025-01-01"]),
+                constants.WATER_TEMPERATURE_DAILY_MEAN: [12.0],
+            }
+        ).set_index(constants.TIME_INDEX)
+
+        assert_frame_equal(result_df, expected_df)
+
+    def test_unsupported_variable_raises(self):
+        with self.assertRaises(ValueError):
+            self.fetcher.get_data("lobith", constants.DISCHARGE_HOURLY_MEAN)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_netherlands.py
+++ b/tests/test_netherlands.py
@@ -1,5 +1,4 @@
 import json
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -13,7 +12,7 @@ from rivretrieve import NetherlandsFetcher, constants
 class TestNetherlandsFetcher(unittest.TestCase):
     def setUp(self):
         self.fetcher = NetherlandsFetcher()
-        self.test_data_dir = Path(os.path.dirname(__file__)) / "test_data"
+        self.test_data_dir = Path(__file__).parent / "test_data"
 
     def _load_json(self, filename):
         with open(self.test_data_dir / filename, "r", encoding="utf-8") as f:
@@ -34,6 +33,7 @@ class TestNetherlandsFetcher(unittest.TestCase):
 
         result_df = self.fetcher.get_metadata()
 
+        self.assertEqual(result_df.index.name, constants.GAUGE_ID)
         self.assertEqual(list(result_df.index), ["borgharen", "lobith"])
         self.assertEqual(result_df.loc["lobith", constants.STATION_NAME], "Lobith")
         self.assertEqual(result_df.loc["lobith", constants.RIVER], "Rijn")
@@ -42,6 +42,11 @@ class TestNetherlandsFetcher(unittest.TestCase):
         self.assertEqual(result_df.loc["lobith", constants.COUNTRY], "Netherlands")
         self.assertEqual(result_df.loc["lobith", constants.SOURCE], self.fetcher.SOURCE)
         self.assertEqual(mock_session.post.call_count, 1)
+        self.assertEqual(mock_session.post.call_args.kwargs["timeout"], 60)
+        self.assertEqual(
+            mock_session.post.call_args.kwargs["json"]["CatalogusFilter"]["Compartimenten"],
+            True,
+        )
 
     def test_available_variables(self):
         self.assertEqual(
@@ -86,6 +91,7 @@ class TestNetherlandsFetcher(unittest.TestCase):
         self.assertEqual(data_body["Locatie"]["Code"], "lobith")
         self.assertEqual(data_body["AquoPlusWaarnemingMetadata"]["AquoMetadata"]["Grootheid"]["Code"], "Q")
         self.assertEqual(data_body["AquoPlusWaarnemingMetadata"]["AquoMetadata"]["Eenheid"]["Code"], "m3/s")
+        self.assertEqual(mock_session.post.call_args_list[1].kwargs["timeout"], 60)
 
     @patch("rivretrieve.utils.requests_retry_session")
     def test_get_data_instant_discharge(self, mock_requests_session):
@@ -180,6 +186,29 @@ class TestNetherlandsFetcher(unittest.TestCase):
     def test_unsupported_variable_raises(self):
         with self.assertRaises(ValueError):
             self.fetcher.get_data("lobith", constants.DISCHARGE_HOURLY_MEAN)
+
+    @patch("rivretrieve.utils.requests_retry_session")
+    def test_get_data_returns_standardized_empty_frame_for_empty_payload(self, mock_requests_session):
+        mock_session = MagicMock()
+        mock_requests_session.return_value = mock_session
+        mock_session.post.side_effect = [
+            self._mock_response(self._load_json("netherlands_catalog_sample.json")),
+            self._mock_response({}),
+        ]
+
+        result_df = self.fetcher.get_data(
+            gauge_id="lobith",
+            variable=constants.DISCHARGE_DAILY_MEAN,
+            start_date="2025-01-01",
+            end_date="2025-01-02",
+        )
+
+        expected_df = pd.DataFrame(columns=[constants.TIME_INDEX, constants.DISCHARGE_DAILY_MEAN]).set_index(
+            constants.TIME_INDEX
+        )
+
+        assert_frame_equal(result_df, expected_df)
+        self.assertEqual(result_df.index.name, constants.TIME_INDEX)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Related to issue #97 

This PR adds Netherlands support to RivRetrieve via a new `NetherlandsFetcher` backed by Rijkswaterstaat WaterWebservices.

## What was added

- new fetcher: `rivretrieve/netherlands.py`
- package export in `rivretrieve/__init__.py`
- documentation page: `docs/fetchers/netherlands.rst`
- API docs entry in `docs/api.rst`
- cached metadata catalog: `rivretrieve/cached_site_data/netherlands_sites.csv`
- example usage script: `examples/test_netherlands_fetcher.py`
- tests and fixtures for metadata, discharge, stage, and temperature retrieval

## Supported variables

- `discharge_daily_mean`
- `discharge_instantaneous`
- `stage_daily_mean`
- `stage_instantaneous`
- `water-temperature_daily_mean`
- `water-temperature_instantaneous`

## Implementation notes

- uses Rijkswaterstaat catalog and observation services
- prefers the current `ddapi20` endpoint family and falls back to the legacy service if needed
- filters metadata to stations supporting at least one RivRetrieve-supported surface-water variable
- aggregates sub-daily observations to daily means for daily products
- keeps native timestamps for instantaneous products
- converts stage from cm to m
- converts discharge from `m3/d` to `m3/s` when needed
- filters provider sentinel missing values from temperature series before aggregation
