### PR TITLE
add support for inst discharge in UKEAFetcher

### DIFF
--- a/rivretrieve/uk_ea.py
+++ b/rivretrieve/uk_ea.py
@@ -19,6 +19,7 @@ class UKEAFetcher(base.RiverDataFetcher):
 
     Supported Variables:
         - ``constants.DISCHARGE_DAILY_MEAN`` (m³/s)
+        - ``constants.DISCHARGE_INSTANT`` (m³/s)
         - ``constants.STAGE_INSTANT`` (m)
     """
 

--- a/rivretrieve/uk_ea.py
+++ b/rivretrieve/uk_ea.py
@@ -154,9 +154,9 @@ class UKEAFetcher(base.RiverDataFetcher):
             return pd.DataFrame(columns=[constants.TIME_INDEX, variable])
 
         df = pd.DataFrame(raw_data)
-        
+
         # Only convert to date if the variable is a daily summary
-        if constants.DAILY in variable: 
+        if constants.DAILY in variable:
             df[constants.TIME_INDEX] = pd.to_datetime(df["dateTime"]).dt.date
         else:
             df[constants.TIME_INDEX] = pd.to_datetime(df["dateTime"])

--- a/rivretrieve/uk_ea.py
+++ b/rivretrieve/uk_ea.py
@@ -169,15 +169,6 @@ class UKEAFetcher(base.RiverDataFetcher):
         df = df.rename(columns={"Value": variable})
         df[constants.TIME_INDEX] = pd.to_datetime(df[constants.TIME_INDEX])
 
-        # # Ensure complete time series within the data range
-        # if not df.empty:
-        #     date_range = pd.date_range(
-        #         start=df[constants.TIME_INDEX].min(),
-        #         end=df[constants.TIME_INDEX].max(),
-        #         freq="D",
-        #     )
-        #     complete_ts = pd.DataFrame(date_range, columns=[constants.TIME_INDEX])
-        #     df = pd.merge(complete_ts, df, on=constants.TIME_INDEX, how="left")
         return df.set_index(constants.TIME_INDEX)
 
     def get_data(

--- a/rivretrieve/uk_ea.py
+++ b/rivretrieve/uk_ea.py
@@ -48,7 +48,7 @@ class UKEAFetcher(base.RiverDataFetcher):
 
     @staticmethod
     def get_available_variables() -> tuple[str, ...]:
-        return (constants.DISCHARGE_DAILY_MEAN, constants.STAGE_INSTANT)
+        return (constants.DISCHARGE_DAILY_MEAN, constants.DISCHARGE_INSTANT, constants.STAGE_INSTANT)
 
     def get_metadata(self) -> pd.DataFrame:
         """Fetches site metadata for all stations from the EA API.
@@ -87,6 +87,8 @@ class UKEAFetcher(base.RiverDataFetcher):
             return "level-i-900-m-qualified"
         elif variable == constants.DISCHARGE_DAILY_MEAN:
             return "flow-m-86400-m3s-qualified"
+        elif variable == constants.DISCHARGE_INSTANT:
+            return "flow-i-900-m3s-qualified"
         else:
             raise ValueError(f"Unsupported variable: {variable}")
 
@@ -152,7 +154,13 @@ class UKEAFetcher(base.RiverDataFetcher):
             return pd.DataFrame(columns=[constants.TIME_INDEX, variable])
 
         df = pd.DataFrame(raw_data)
-        df[constants.TIME_INDEX] = pd.to_datetime(df["dateTime"]).dt.date
+        
+        # Only convert to date if the variable is a daily summary
+        if constants.DAILY in variable: 
+            df[constants.TIME_INDEX] = pd.to_datetime(df["dateTime"]).dt.date
+        else:
+            df[constants.TIME_INDEX] = pd.to_datetime(df["dateTime"])
+
         df["Value"] = pd.to_numeric(df["value"], errors="coerce")
 
         df = df[[constants.TIME_INDEX, "Value"]]
@@ -160,16 +168,15 @@ class UKEAFetcher(base.RiverDataFetcher):
         df = df.rename(columns={"Value": variable})
         df[constants.TIME_INDEX] = pd.to_datetime(df[constants.TIME_INDEX])
 
-        # Ensure complete time series within the data range
-        if not df.empty:
-            date_range = pd.date_range(
-                start=df[constants.TIME_INDEX].min(),
-                end=df[constants.TIME_INDEX].max(),
-                freq="D",
-            )
-            complete_ts = pd.DataFrame(date_range, columns=[constants.TIME_INDEX])
-            df = pd.merge(complete_ts, df, on=constants.TIME_INDEX, how="left")
-
+        # # Ensure complete time series within the data range
+        # if not df.empty:
+        #     date_range = pd.date_range(
+        #         start=df[constants.TIME_INDEX].min(),
+        #         end=df[constants.TIME_INDEX].max(),
+        #         freq="D",
+        #     )
+        #     complete_ts = pd.DataFrame(date_range, columns=[constants.TIME_INDEX])
+        #     df = pd.merge(complete_ts, df, on=constants.TIME_INDEX, how="left")
         return df.set_index(constants.TIME_INDEX)
 
     def get_data(


### PR DESCRIPTION
Related to #41 
This PR extends UKEAFetcher to support retrieval of instantaneous (15 min) discharge data. It also fixes an issue with the return time index, whereby the time was removed from instantaneous measurements (e.g. 2026-18-01 16:15:00 became 2026-18-01). 